### PR TITLE
[TS-197] ESLint sdk 버전 8.2.0으로 변경

### DIFF
--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "8.56.0-sdk",
+  "version": "8.2.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs",
   "bin": {


### PR DESCRIPTION
[TS-197](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109/backlog?selectedIssue=TS-197)

## 💡 변경사항 & 이슈
ESLint sdk 버전 8.56.0 에서 8.2.0으로 변경
<br>

## ✍️ 관련 설명
package.json에 있는 eslint 버전과 sdk 버전 8.2.0으로 일치시킴 
<br>

## ⭐️ Review point
버전 변경 잘 되었는지 확인 부탁드립니다.
<br>

## 📷 Demo
없음
<br>


[TS-197]: https://m2jun.atlassian.net/browse/TS-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ