### PR TITLE
[TS-268] Chore ESLint rule refactor

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,11 +55,6 @@
               "position": "before"
             },
             {
-              "pattern": "@/components/**/*",
-              "group": "type",
-              "position": "before"
-            },
-            {
               "pattern": "@/hooks/**/*",
               "group": "type",
               "position": "before"
@@ -78,6 +73,26 @@
               "pattern": "@/utils/**/*",
               "group": "type",
               "position": "before"
+            },
+            {
+              "pattern": "@/pages/**/*.style",
+              "group": "unknown"
+            },
+            {
+              "pattern": "@/components/**/*.style",
+              "group": "unknown"
+            },
+            {
+              "pattern": "@/components/*.style",
+              "group": "unknown"
+            },
+            {
+              "pattern": "../**/*.style",
+              "group": "unknown"
+            },
+            {
+              "pattern": "./**/*.style",
+              "group": "unknown"
             }
           ],
           "pathGroupsExcludedImportTypes": ["react", "unknown"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,80 +1,100 @@
 {
-    "env": {
-      "browser": true,
-      "es6": true,
-      "node": true
-    },
-    "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint","import"],
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:prettier/recommended"
-    ],
-    "rules": {
-      "import/order":[
-        "error",
-          {
-            "groups": [
-              "builtin",
-              "external",
-              "internal",
-              ["sibling", "parent", "index"],
-              "type",
-              "unknown"
-            ],
-            "pathGroups": [
-              {
-                "pattern": "{react*,react*/*}",
-                "group": "external",
-                "position": "before"
-              },
-              {
-                "pattern": "{axios*,axios*/*}",
-                "group": "external",
-                "position": "before"
-              },
-              {
-                "pattern": "{@emotion*,@emotion*/*}",
-                "group": "external",
-                "position": "before"
-              },
-              {
-                "pattern": "@/pages/**/*.style",
-                "group": "unknown"
-              },
-              {
-                "pattern": "@/components/**/*.style",
-                "group": "unknown"
-              },
-              {
-                "pattern": "@/components/*.style",
-                "group": "unknown"
-              },
-              {
-                "pattern": "../**/*.style",
-                "group": "unknown"
-              },
-              {
-                "pattern": "./**/*.style",
-                "group": "unknown"
-              }
-            ],
-            "pathGroupsExcludedImportTypes": ["react", "unknown"],
-            "alphabetize": {
-              "order": "asc",
-              "caseInsensitive": true
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint","import"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended"
+  ],
+  "rules": {
+    "import/order":[
+      "error",
+        {
+          "groups": [
+            "builtin",
+            "external",
+            "internal",
+            ["sibling", "parent", "index"],
+            "type",
+            "unknown"
+          ],
+          "pathGroups": [
+            {
+              "pattern": "{react*,react*/*}",
+              "group": "external",
+              "position": "before"
             },
-            "newlines-between": "always"
-          }
-        ]
-    },
-    "settings": { 
-      "import/parsers": {
-        "@typescript-eslint/parser": [".ts", ".tsx", ".js"] 
-      }, 
-      "import/resolver": { 
-        "typescript": "./tsconfig.json" 
-      }
+            {
+              "pattern": "{axios*,axios*/*}",
+              "group": "external",
+              "position": "before"
+            },
+            {
+              "pattern": "{@emotion*,@emotion*/*}",
+              "group": "external",
+              "position": "before"
+            },
+            {
+              "pattern": "@/assets/**/*",
+              "group": "internal",
+              "position": "before"
+            },
+            {
+              "pattern": "@/api/**/*",
+              "group": "type",
+              "position": "before"
+            },
+            {
+              "pattern": "@/constants/**/*",
+              "group": "type",
+              "position": "before"
+            },
+            {
+              "pattern": "@/components/**/*",
+              "group": "type",
+              "position": "before"
+            },
+            {
+              "pattern": "@/hooks/**/*",
+              "group": "type",
+              "position": "before"
+            },
+            {
+              "pattern": "@/pages/**/*",
+              "group": "type",
+              "position": "before"
+            },
+            {
+              "pattern": "@/styles/**/*",
+              "group": "type",
+              "position": "before"
+            },
+            {
+              "pattern": "@/utils/**/*",
+              "group": "type",
+              "position": "before"
+            }
+          ],
+          "pathGroupsExcludedImportTypes": ["react", "unknown"],
+          "alphabetize": {
+            "order": "asc",
+            "caseInsensitive": true
+          },
+          "newlines-between": "always"
+        }
+      ]
+  },
+  "settings": { 
+    "import/parsers": {
+      "@typescript-eslint/parser": [".ts", ".tsx", ".js"] 
+    }, 
+    "import/resolver": { 
+      "typescript": "./tsconfig.json" 
     }
   }
+}


### PR DESCRIPTION
[TS-268](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109/backlog?epics=visible&selectedIssue=TS-268)

## 💡 변경사항 & 이슈
ESLint import order 순서 변경

## ✍️ 관련 설명
디렉토리별 import 구문 간 줄바꿈이 있어야 가독성이 좋을 거 같아서 수정했습니다.
style 파일이 꼭 컴포넌트 파일 윗줄에 있는건 설정이 불가능 했습니다. 오직 알파벳 순으로 정렬되다 보니 어쩔 수 없을 거 같네요
차라리 동일하게 style 파일은 가장 하단에 위치하는게 좋을 거 같아서 그대로 유지했습니다.

## ⭐️ Review point
.

## 📷 Demo
.


[TS-268]: https://m2jun.atlassian.net/browse/TS-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ