### PR TITLE
[TS-271] Feat habit history page history delete modal

### DIFF
--- a/src/components/MyPage/HabitHistory/DeleteHistoryModal.tsx
+++ b/src/components/MyPage/HabitHistory/DeleteHistoryModal.tsx
@@ -1,0 +1,29 @@
+import { useAppDispatch } from "@/api/hooks";
+import { closeModal } from "@/api/modal/modalSlice";
+import Modal from "@/components/common/Modal/Modal";
+
+import {
+	layoutStyle,
+	buttonBoxStyle,
+} from "@/components/MyPage/MyInfo/LogoutModal/LogoutModal.style";
+
+const DeleteHistoryModal = () => {
+	const dispatch = useAppDispatch();
+
+	return (
+		<Modal>
+			<div css={layoutStyle}>
+				<h1>지난 히스토리를 삭제할까요?</h1>
+
+				<div css={buttonBoxStyle}>
+					<button className="cancel" onClick={() => dispatch(closeModal())}>
+						취소
+					</button>
+					<button>삭제</button>
+				</div>
+			</div>
+		</Modal>
+	);
+};
+
+export default DeleteHistoryModal;

--- a/src/components/MyPage/HabitHistory/DeleteHistoryModal.tsx
+++ b/src/components/MyPage/HabitHistory/DeleteHistoryModal.tsx
@@ -1,6 +1,7 @@
+import Modal from "@/components/common/Modal/Modal";
+
 import { useAppDispatch } from "@/api/hooks";
 import { closeModal } from "@/api/modal/modalSlice";
-import Modal from "@/components/common/Modal/Modal";
 
 import {
 	layoutStyle,

--- a/src/components/MyPage/HabitHistory/HabitCard.tsx
+++ b/src/components/MyPage/HabitHistory/HabitCard.tsx
@@ -1,7 +1,10 @@
+import CloseIcon from "@/assets/icon/ic-close.svg?react";
+
+import DeleteHistoryModal from "@/components/MyPage/HabitHistory/DeleteHistoryModal";
+
 import { useAppDispatch, useAppSelector } from "@/api/hooks";
 import { openModal } from "@/api/modal/modalSlice";
-import CloseIcon from "@/assets/icon/ic-close.svg?react";
-import DeleteHistoryModal from "@/components/MyPage/HabitHistory/DeleteHistoryModal";
+
 import { modalType } from "@/constants/modalConstants";
 
 import {

--- a/src/components/MyPage/HabitHistory/HabitCard.tsx
+++ b/src/components/MyPage/HabitHistory/HabitCard.tsx
@@ -1,4 +1,8 @@
+import { useAppDispatch, useAppSelector } from "@/api/hooks";
+import { openModal } from "@/api/modal/modalSlice";
 import CloseIcon from "@/assets/icon/ic-close.svg?react";
+import DeleteHistoryModal from "@/components/MyPage/HabitHistory/DeleteHistoryModal";
+import { modalType } from "@/constants/modalConstants";
 
 import {
 	layoutStyle,
@@ -7,6 +11,7 @@ import {
 } from "@/components/MyPage/HabitHistory/HabitCard.style";
 
 interface habitCardDataType {
+	id: number;
 	isEnd: boolean;
 	title: string;
 	startDate: string;
@@ -17,6 +22,7 @@ interface habitCardDataType {
 }
 
 const HabitCard = ({
+	id,
 	isEnd,
 	title,
 	startDate,
@@ -25,9 +31,13 @@ const HabitCard = ({
 	failCount,
 	endReason,
 }: habitCardDataType) => {
+	const dispatch = useAppDispatch();
+
+	const { modal } = useAppSelector((state) => state.modal);
+
 	return (
 		<div css={layoutStyle}>
-			{isEnd && <CloseIcon />}
+			{isEnd && <CloseIcon onClick={() => dispatch(openModal(modalType.DELETE_HISTORY(id)))} />}
 			<h1>{title}</h1>
 
 			{isEnd ? (
@@ -51,6 +61,7 @@ const HabitCard = ({
 					<span>휴식 : {failCount}</span>
 				</p>
 			)}
+			{modal === modalType.DELETE_HISTORY(id) && <DeleteHistoryModal />}
 		</div>
 	);
 };

--- a/src/components/MyPage/HabitHistory/HabitHistory.tsx
+++ b/src/components/MyPage/HabitHistory/HabitHistory.tsx
@@ -11,6 +11,7 @@ import {
 
 const notEndHabitData = [
 	{
+		id: 12,
 		isEnd: false,
 		title: "오후 8시에 우리 집 안 내 책상 위에서 책 읽기 5 페이지",
 		startDate: "2023. 12. 11.",
@@ -18,6 +19,7 @@ const notEndHabitData = [
 		failCount: 13,
 	},
 	{
+		id: 13,
 		isEnd: false,
 		title: "오후 8시에 우리 집 안 내 책상 위에서 책 읽기 5 페이지2",
 		startDate: "2023. 12. 11.",
@@ -28,6 +30,7 @@ const notEndHabitData = [
 
 const endHabitData = [
 	{
+		id: 14,
 		isEnd: true,
 		title: "오후 123시에 우리 집 안 내 책상 위에서 책 읽기 123 페이지",
 		startDate: "2023. 12. 11.",
@@ -37,6 +40,7 @@ const endHabitData = [
 		endReason: "실천하기 어려운 습관이에요",
 	},
 	{
+		id: 15,
 		isEnd: true,
 		title: "오후 123시에 우리 집 안 내 책상 위에서 책 읽기 123 페이지2",
 		startDate: "2023. 12. 11.",
@@ -67,9 +71,10 @@ const HabitHistory = () => {
 			<div css={dividerStyle} />
 			<div css={cardBoxStyle}>
 				{tab === "실천 중" &&
-					notEndHabitData.map(({ isEnd, title, startDate, successCount, failCount }) => (
+					notEndHabitData.map(({ id, isEnd, title, startDate, successCount, failCount }) => (
 						<HabitCard
 							key={title}
+							id={id}
 							isEnd={isEnd}
 							title={title}
 							startDate={startDate}
@@ -80,9 +85,10 @@ const HabitHistory = () => {
 
 				{tab === "지난" &&
 					endHabitData.map(
-						({ isEnd, title, startDate, endDate, successCount, failCount, endReason }) => (
+						({ id, isEnd, title, startDate, endDate, successCount, failCount, endReason }) => (
 							<HabitCard
 								key={title}
+								id={id}
 								isEnd={isEnd}
 								title={title}
 								startDate={startDate}

--- a/src/constants/modalConstants.ts
+++ b/src/constants/modalConstants.ts
@@ -7,4 +7,5 @@ export const modalType = {
 	SELECT_IDENTITY: "SELECT_IDENTITY",
 	LOGOUT: "LOGOUT",
 	SORT: "SORT",
+	DELETE_HISTORY: (id: number) => `DELETE_HISTORY_${id}`,
 };


### PR DESCRIPTION
[TS-271](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=712020%3Add928be4-89fa-4c60-9aa8-e0ad8f6b5a7b&selectedIssue=TS-271)

## 💡 변경사항 & 이슈
습관현황 히스토리 페이지 히스토리 삭제 모달 구현

## ✍️ 관련 설명
습관현황 히스토리 페이지 히스토리 삭제 모달 구현

## ⭐️ Review point
각 습관 현황의 id에 맞는 모달이 켜지도록 구현했습니다.
삭제 기능은 api 나오고 제작 예정입니다.

## 📷 Demo
<img width="361" alt="스크린샷 2024-02-18 오후 5 59 51" src="https://github.com/ConnectingStar/ConnectingStar-Front/assets/100590110/8bcfeef0-01f3-4264-8676-f6161db5e626">



[TS-271]: https://m2jun.atlassian.net/browse/TS-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ