### PR TITLE
[TS-274] 공통 Header 컴포넌트로 교체

### DIFF
--- a/src/pages/StarCardDetailPage.style.ts
+++ b/src/pages/StarCardDetailPage.style.ts
@@ -6,11 +6,6 @@ export const sectionStyle = css`
 	margin: 0 auto;
 `;
 
-// TODO: Header 컴포넌트 머지 되면 교체 예정
-export const headerStyle = css`
-	height: 56px;
-`;
-
 // TODO: 공통 버튼 컴포넌트 추가되면 교체 예정
 export const buttonContainerStyle = css`
 	margin-top: 1rem;

--- a/src/pages/StarCardDetailPage.tsx
+++ b/src/pages/StarCardDetailPage.tsx
@@ -1,11 +1,13 @@
+import Header from "@/components/common/Header/Header";
 import Button from "@/components/StarCardDetail/Button";
 import CategoryLabel from "@/components/StarCardDetail/CategoryLabel";
 import Img from "@/components/StarCardDetail/Img/Img";
 import Story from "@/components/StarCardDetail/Story";
 import Title from "@/components/StarCardDetail/Title";
+
 import { buttonState } from "@/constants/starCardDetailConstants";
 
-import { sectionStyle, headerStyle, buttonContainerStyle } from "@/pages/StarCardDetailPage.style";
+import { sectionStyle, buttonContainerStyle } from "@/pages/StarCardDetailPage.style";
 
 // TODO: API 연결 후 삭제 예정(상태에 따른 Img, Button UI 변경 확인 용)
 interface dataType {
@@ -17,11 +19,13 @@ const data: dataType = {
 	state: "have",
 };
 
-// TODO: Header, Button 공통 컴포넌트 머지되면 교체 예정
+// TODO: Button 공통 컴포넌트 머지되면 교체 예정
 export default function StarCardDetailPage() {
 	return (
 		<>
-			<header css={headerStyle}></header>
+			<Header>
+				<Header.PrevButton />
+			</Header>
 			<section css={sectionStyle}>
 				<Img state={data.state} />
 				<Title tag="h2">캐릭터 설명 문구</Title>


### PR DESCRIPTION
[TS-274](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?selectedIssue=TS-274)

## 💡 변경사항 & 이슈
별자리 상세 페이지 Header 교체
<br>

## ✍️ 관련 설명
- /star/1로 접근해서 확인할 수 있습니다. 
- 별자리 상세 페이지의 기존 Header를 공통 Header 컴포넌트로 교체했습니다. 
- 교체 후 필요없어진 코드 및 주석을 삭제했습니다. 
- import order도 새 규칙에 맞게 변경되었습니다. (이전에 확인하고 머지 했어야 했는데 깜빡하고 못했네요 다음부턴 신경 쓰겠습니다~)
<br>

## ⭐️ Review point
변경 잘 되었는지 확인 부탁드립니다.
<br>

## 📷 Demo
<img width="300" alt="스크린샷 2024-02-19 오후 9 26 20" src="https://github.com/ConnectingStar/ConnectingStar-Front/assets/77181642/553c8b76-63c9-46ee-89bb-0f54039f5f3d">


<br>


[TS-274]: https://m2jun.atlassian.net/browse/TS-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ