### PR TITLE
[TS-305] 별자리 카드 제목 padding 수정

### DIFF
--- a/src/components/StarPage/StarCard/StarCard.style.ts
+++ b/src/components/StarPage/StarCard/StarCard.style.ts
@@ -50,7 +50,7 @@ export const haveLabelStyle = css`
 `;
 
 export const titleStyle = css`
-	padding-top: 1rem;
+	padding-top: 0.75rem;
 	text-align: center;
 
 	strong {


### PR DESCRIPTION
[TS-305](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-305)

## 💡 변경사항 & 이슈
별자리 카드 페이지의 카드 padding을 수정했습니다. 
<br>

## ✍️ 관련 설명
- /star-card 경로에서 확인 가능
- 디자인 시안과 카드 여백이 달라서 동일하게 수정했습니다(16px -> 12px)
<br>

## ⭐️ Review point
<br>

## 📷 Demo
<img width="300" alt="스크린샷 2024-04-10 오전 10 26 10" src="https://github.com/ConnectingStar/ConnectingStar-Front/assets/77181642/0191ce4d-44d6-4147-a9c4-bf6c3a5cf395">

<br>


[TS-305]: https://m2jun.atlassian.net/browse/TS-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ