### PR TITLE
[TS-28] habitRecord padding top, FooterBtn Fixed 설정 후 padding bottom 수정

### DIFF
--- a/src/components/Home/HabitRecord/HabitRecord.style.ts
+++ b/src/components/Home/HabitRecord/HabitRecord.style.ts
@@ -7,7 +7,7 @@ export const layoutStyle = css`
 	flex-direction: column;
 	width: 22.5rem;
 	margin: 0 auto;
-	padding: 1.5rem;
+	padding: 4.75rem 1.5rem 5.438rem;
 	gap: 40px;
 	white-space: pre-wrap;
 	${theme.font.body_a};
@@ -23,6 +23,7 @@ export const layoutStyle = css`
 		padding: 0.9375rem;
 		resize: none;
 	}
+
 	input::placeholder {
 		${theme.color.button_deactivated}
 	}

--- a/src/components/Home/HabitRecord/HabitRecord.tsx
+++ b/src/components/Home/HabitRecord/HabitRecord.tsx
@@ -128,7 +128,6 @@ function HabitRecord() {
 			<FooterBtn
 				handleBtnClick={() => dispatch(openModal(modalType.STAR_PRIZE))}
 				text="기록하여 별 얻기"
-				isPositionStatic
 				isTransparent
 				disabled={!isActivated || !selectedIcon}
 			/>


### PR DESCRIPTION
[TS-28](https://m2jun.atlassian.net/browse/TS-28)

## 💡 변경사항 & 이슈
/habit-record

-스크롤되는 페이지는 FooterBtn 고정된다고 해서 Fixed설정하고 padding-bottom 5.438rem설정했습니다.
-헤더 높이 3.5rem만큼 추가해서 수정했습니다. 이전 설정에서 1.25rem인게 1.5rem으로 되어있어서 4.75rem 총합으로 수정했습니다.


<br>

## ✍️ 관련 설명
<br>

## ⭐️ Review point
<br>

## 📷 Demo
<img width="343" alt="스크린샷 2024-04-11 오후 4 36 18" src="https://github.com/ConnectingStar/ConnectingStar-Front/assets/117588223/5842a15a-4dc1-4e08-a7c5-2c350bfedbb8">

<br>


[TS-28]: https://m2jun.atlassian.net/browse/TS-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ