### PR TITLE
[TS-320] 변경된 별자리 카드 상세 페이지 디자인 반영

### DIFF
--- a/src/components/StarPage/StarCardDetail/CategoryLabel.style.ts
+++ b/src/components/StarPage/StarCardDetail/CategoryLabel.style.ts
@@ -6,7 +6,6 @@ export const containerStyle = css`
 	display: flex;
 	flex-wrap: wrap;
 	gap: 0.375rem;
-	margin-bottom: 2.5rem;
 `;
 
 export const categoryLabelStyle = css`

--- a/src/pages/StarCardDetailPage.tsx
+++ b/src/pages/StarCardDetailPage.tsx
@@ -48,12 +48,12 @@ export default function StarCardDetailPage() {
 			</Header>
 			<section css={sectionStyle}>
 				<Img state={data.state} />
-				<h2>캐릭터 설명 문구</h2>
-				<h1>캐릭터 이름</h1>
 				<CategoryLabel />
+				<h1>캐릭터 이름</h1>
+				<h2>정체성</h2>
 				<Story />
 			</section>
-			<FooterBtn text={buttonState[data.state]} handleBtnClick={handleModal} isTransparent />
+			<FooterBtn text={buttonState[data.state]} handleBtnClick={handleModal} />
 
 			{modal === modalType.SELECT_STAR && <SelectStarModal />}
 			{modal === modalType.SELECT_PROFILE_CHARACTER && <SelectProfileCharacterModal />}
@@ -67,13 +67,14 @@ const sectionStyle = css`
 	margin: 0 auto;
 
 	& > h1 {
-		margin-bottom: 0.5625rem;
+		margin-top: 0.375rem;
 		${theme.font.head_a}
 		color: ${theme.color.font_black};
 	}
 
 	& > h2 {
-		${theme.font.head_b}
-		color: ${theme.color.main_blue};
+		margin-bottom: 2.5rem;
+		${theme.font.body_a}
+		color: ${theme.color.font_black};
 	}
 `;


### PR DESCRIPTION
[TS-320](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-320)

## 💡 변경사항 & 이슈
별자리 카드 상세 페이지 UI 위치 변경
<br>

## ✍️ 관련 설명
변경된 별자리 카드 상세 페이지 디자인을 반영했습니다. 
- /star-card/:id 경로에서 확인 가능합니다. 
- 페이지가 스크롤 될 때 FooterBtn의 흰색 배경도 함께 고정되어야 한다고 해서 isTransparent를 삭제했습니다. (디자인방 참고)
<br>

## ⭐️ Review point
디자인 시안과 다른 부분 없는지 확인 부탁드립니다. 
<br>

## 📷 Demo
<img width="300" alt="스크린샷 2024-04-25 오후 5 18 22" src="https://github.com/ConnectingStar/ConnectingStar-Front/assets/77181642/be8e0b7f-1946-4b80-a0df-e45bfcf235df">

<br>



[TS-320]: https://m2jun.atlassian.net/browse/TS-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ