### PR TITLE
[TS-325] Oauth 로그인

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 3000",
     "build": "tsc && vite build",
     "lint": "eslint './src/**/*.{ts,tsx,js,jsx}'",
     "lint:fix": "eslint --fix './src/**/*.{ts,tsx,js,jsx}'",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import ToastContainer from "@/components/common/Toast/ToastContainer/ToastContainer";
 
+import KakaoLoginPage from "./pages/KakaoLoginPage";
+
 import ChartPage from "@/pages/ChartPage";
 import ChattingPage from "@/pages/ChattingPage";
 import HabitDeletePage from "@/pages/HabitDeletePage";
@@ -19,8 +21,8 @@ import RestRecordPage from "@/pages/RestRecordPage";
 import StarCardDetailPage from "@/pages/StarCardDetailPage";
 import StarCardPage from "@/pages/StarCardPage";
 import StarMainPage from "@/pages/StarMainPage/StarMainPage";
-import TestPage from "@/pages/TestPage";
 import WithdrawalPage from "@/pages/WithdrawalPage";
+
 const App = () => {
 	return (
 		<>
@@ -42,9 +44,9 @@ const App = () => {
 					<Route path="/chatting" element={<ChattingPage />} />
 					<Route path="/habit-delete" element={<HabitDeletePage />} />
 					<Route path="/onboarding" element={<OnboardingPage />} />
+					<Route path="/oauth2/kakao" element={<KakaoLoginPage />} />
 					<Route path="/habit-record" element={<HabitRecordPage />} />
 					<Route path="/habit-generate" element={<HabitGeneratePage />} />
-					<Route path="/test" element={<TestPage />} />
 				</Routes>
 			</BrowserRouter>
 			<ToastContainer />

--- a/src/api/auth/authSlice.ts
+++ b/src/api/auth/authSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+interface authStateType {
+	isLogin: boolean | null;
+}
+
+const initialState: authStateType = {
+	isLogin: null,
+};
+
+const authSlice = createSlice({
+	name: "auth",
+	initialState,
+	reducers: {
+		login: (state) => {
+			state.isLogin = true;
+		},
+		logout: (state) => {
+			state.isLogin = false;
+		},
+	},
+});
+
+export const { login, logout } = authSlice.actions;
+
+export const authReducer = authSlice.reducer;

--- a/src/api/auth/authThunk.ts
+++ b/src/api/auth/authThunk.ts
@@ -31,3 +31,11 @@ export const postFCMToken = createAsyncThunk(
 		}
 	},
 );
+
+export const logOut = createAsyncThunk("auth/logOut", async (_, thunkOptions) => {
+	try {
+		return await axiosInstance.delete(END_POINTS.LOGOUT);
+	} catch (error) {
+		throw thunkOptions.rejectWithValue(error);
+	}
+});

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 import { BASE_URL } from "@/constants/api";
 
-import { getCookie } from "@/utils/getCookie";
+// import { getCookie } from "@/utils/getCookie";
 
 export const axiosInstance = axios.create({
 	baseURL: BASE_URL,
@@ -10,32 +10,32 @@ export const axiosInstance = axios.create({
 	withCredentials: true,
 });
 
-axiosInstance.interceptors.request.use(
-	(config) => {
-		const accessToken = getCookie("tars_token");
-		if (!accessToken) {
-			window.location.href = "/onboarding?step=CreateAccount";
-			return config;
-		}
+// axiosInstance.interceptors.request.use(
+// 	(config) => {
+// 		const accessToken = getCookie("tars_token");
+// 		if (!accessToken) {
+// 			window.location.href = "/onboarding?step=CreateAccount";
+// 			return config;
+// 		}
 
-		config.headers["Content-Type"] = "application/json";
+// 		config.headers["Content-Type"] = "application/json";
 
-		return config;
-	},
-	(error) => {
-		console.log(error);
-		return Promise.reject(error);
-	},
-);
+// 		return config;
+// 	},
+// 	(error) => {
+// 		console.log(error);
+// 		return Promise.reject(error);
+// 	},
+// );
 
-axiosInstance.interceptors.response.use(
-	(response) => {
-		return response;
-	},
-	(error) => {
-		if (error.response && error.response.status === 401) {
-			window.location.href = "/onboarding?step=CreateAccount";
-		}
-		return Promise.reject(error);
-	},
-);
+// axiosInstance.interceptors.response.use(
+// 	(response) => {
+// 		return response;
+// 	},
+// 	(error) => {
+// 		if (error.response && error.response.status === 401) {
+// 			window.location.href = "/onboarding?step=CreateAccount";
+// 		}
+// 		return Promise.reject(error);
+// 	},
+// );

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -2,11 +2,40 @@ import axios from "axios";
 
 import { BASE_URL } from "@/constants/api";
 
+import { getCookie } from "@/utils/getCookie";
+
 export const axiosInstance = axios.create({
 	baseURL: BASE_URL,
 	timeout: 3000,
-	// 원래 true임 fcm 테스트시 미인증 상태라 false로 해놓음
-	withCredentials: false,
+	withCredentials: true,
 });
 
-// 토큰 체크, 에러 코드 interceptors 추가 예정
+axiosInstance.interceptors.request.use(
+	(config) => {
+		const accessToken = getCookie("tars_token");
+		if (!accessToken) {
+			window.location.href = "/onboarding?step=CreateAccount";
+			return config;
+		}
+
+		config.headers["Content-Type"] = "application/json";
+
+		return config;
+	},
+	(error) => {
+		console.log(error);
+		return Promise.reject(error);
+	},
+);
+
+axiosInstance.interceptors.response.use(
+	(response) => {
+		return response;
+	},
+	(error) => {
+		if (error.response && error.response.status === 401) {
+			window.location.href = "/onboarding?step=CreateAccount";
+		}
+		return Promise.reject(error);
+	},
+);

--- a/src/api/store.ts
+++ b/src/api/store.ts
@@ -1,5 +1,6 @@
 import { configureStore } from "@reduxjs/toolkit";
 
+import { authReducer } from "@/api/auth/authSlice";
 import { modalReducer } from "@/api/modal/modalSlice";
 import { toastReducer } from "@/api/toast/toastSlice";
 import { userReducer } from "@/api/user/userSlice";
@@ -9,6 +10,7 @@ export const store = configureStore({
 		modal: modalReducer,
 		user: userReducer,
 		toast: toastReducer,
+		auth: authReducer,
 	},
 	middleware: (getDefaultMiddleware) =>
 		getDefaultMiddleware({

--- a/src/api/store.ts
+++ b/src/api/store.ts
@@ -2,7 +2,7 @@ import { configureStore } from "@reduxjs/toolkit";
 
 import { modalReducer } from "@/api/modal/modalSlice";
 import { toastReducer } from "@/api/toast/toastSlice";
-import userReducer from "@/api/user/userSlice";
+import { userReducer } from "@/api/user/userSlice";
 
 export const store = configureStore({
 	reducer: {

--- a/src/api/user/userSlice.ts
+++ b/src/api/user/userSlice.ts
@@ -41,4 +41,4 @@ const userSlice = createSlice({
 });
 
 export const { updateBasicUserData, updateVisitorRoute, updateHabitUserData } = userSlice.actions;
-export default userSlice.reducer;
+export const userReducer = userSlice.reducer;

--- a/src/components/Chatting/ChattingMessage.tsx
+++ b/src/components/Chatting/ChattingMessage.tsx
@@ -40,6 +40,9 @@ function ChattingMessage({ chatData, setProgress }: chatType) {
 		setProgress((prev) => prev + 1);
 		setMessageIndex((prevIndex) => prevIndex + 1);
 		setIsReply(true);
+		if (chatData.id === "last") {
+			localStorage.setItem("First visit", "false");
+		}
 	};
 
 	// 특정 메시지의 단어 파란색으로 변경하는 함수

--- a/src/components/Onboarding/OauthSignup/OauthSignUp.tsx
+++ b/src/components/Onboarding/OauthSignup/OauthSignUp.tsx
@@ -5,8 +5,7 @@ import KakaoIcon from "@/assets/icon/ic-signup.kakao.svg";
 import LogoImg from "@/assets/image/img-logo-black.png";
 
 import Header from "@/components/common/Header/Header";
-
-import FooterPrivacyPolicyLink from "./FooterPrivacyPolicyLink";
+import FooterPrivacyPolicyLink from "@/components/Onboarding/OauthSignup/FooterPrivacyPolicyLink";
 
 import { BASE_URL } from "@/constants/api";
 

--- a/src/components/Onboarding/OauthSignup/OauthSignUp.tsx
+++ b/src/components/Onboarding/OauthSignup/OauthSignUp.tsx
@@ -8,11 +8,15 @@ import Header from "@/components/common/Header/Header";
 
 import FooterPrivacyPolicyLink from "./FooterPrivacyPolicyLink";
 
+import { BASE_URL } from "@/constants/api";
+
 import { theme } from "@/styles/theme";
 
 function OauthSignUp({ onNext }: { onNext: () => void }) {
-	// TODO: oauth로그인 성공 후 다음페이지로 넘어가기
-	// TODO: header fixed 넣기
+	const kakaoLogin = () => {
+		window.location.href = `${BASE_URL}oauth/code/url?socialType=K`;
+	};
+
 	return (
 		<>
 			<Header>
@@ -22,7 +26,7 @@ function OauthSignUp({ onNext }: { onNext: () => void }) {
 				<div css={wrap}>
 					<img src={LogoImg} alt="logo" />
 					<div>
-						<button type="button" onClick={onNext}>
+						<button type="button" onClick={kakaoLogin}>
 							<img src={KakaoIcon} alt="kakao-icon" />
 							카카오로 계속하기
 						</button>

--- a/src/components/Onboarding/OauthSignup/OauthSignUp.tsx
+++ b/src/components/Onboarding/OauthSignup/OauthSignUp.tsx
@@ -14,7 +14,7 @@ import { theme } from "@/styles/theme";
 
 function OauthSignUp({ onNext }: { onNext: () => void }) {
 	const kakaoLogin = () => {
-		window.location.href = `${BASE_URL}oauth/code/url?socialType=K`;
+		window.location.href = `${BASE_URL}/oauth/code/url?socialType=K`;
 	};
 
 	return (

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -3,5 +3,5 @@ export const BASE_URL = import.meta.env.VITE_BASE_URL;
 export const END_POINTS = {
 	FCM: "/api/fcm/register",
 	LOGIN: (authCode: string | null) => `${BASE_URL}/oauth/login?socialType=K&authCode=${authCode}`,
-	LOGOUT: "/oauth/unlink/kakao",
+	LOGOUT: "/oauth/logout",
 };

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -2,4 +2,6 @@ export const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 export const END_POINTS = {
 	FCM: "/api/fcm/register",
+	LOGIN: (authCode: string | null) => `${BASE_URL}/oauth/login?socialType=K&authCode=${authCode}`,
+	LOGOUT: "/oauth/unlink/kakao",
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ReactDOM from "react-dom/client";
 import { Provider } from "react-redux";
 
@@ -13,13 +12,11 @@ import { GlobalStyle } from "@/styles/globalStyle";
 import { theme } from "@/styles/theme";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-	<React.StrictMode>
-		<Provider store={store}>
-			<ThemeProvider theme={theme}>
-				<Global styles={GlobalStyle} />
-				<App />
-				<ToastBase />
-			</ThemeProvider>
-		</Provider>
-	</React.StrictMode>,
+	<Provider store={store}>
+		<ThemeProvider theme={theme}>
+			<Global styles={GlobalStyle} />
+			<App />
+			<ToastBase />
+		</ThemeProvider>
+	</Provider>,
 );

--- a/src/pages/KakaoLoginPage.tsx
+++ b/src/pages/KakaoLoginPage.tsx
@@ -1,12 +1,44 @@
 import { useEffect } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
-import { axiosInstance } from "@/api/axiosInstance";
+import axios from "axios";
+
+import { END_POINTS } from "@/constants/api";
+
+// 해당 페이지에서 이미 회원가입이 된 유저면 서버단에서는 현재 보이는 에러 페이지가 아니라 리다이렉트를 home으로 시켜줘야합니다.
 
 function KakaoLoginPage() {
 	const navigate = useNavigate();
+
 	const [searchParams] = useSearchParams();
+
 	const authCode = searchParams.get("code");
+
+	const fetchAccessToken = async (authCode: string) => {
+		try {
+			// api 주소 삭제 및 constants 처리
+			const response = await axios.post(
+				END_POINTS.LOGIN(authCode),
+				{},
+				{ withCredentials: true, headers: { "Content-Type": "application/json" } },
+			);
+
+			if (response.status === 200) {
+				navigate("/onboarding?step=CreateAccount");
+			}
+
+			// 불필요 코드 url이 서버단이기 때문에 어차피 작동을 안합니다 확인하시면 지워주세요
+			// if (response.status === 403) {
+			// 	navigate("/");
+			// }
+		} catch (error) {
+			// 에러날 가능성이 없지만 에러시 소셜 로그인 버튼 페이지로 이동
+			navigate("/onboarding?step=OauthSignUp");
+
+			console.error("error fetching access token:", error);
+		}
+	};
 
 	useEffect(() => {
 		if (authCode !== null) {
@@ -14,26 +46,7 @@ function KakaoLoginPage() {
 		}
 	}, [authCode]);
 
-	const fetchAccessToken = async (authCode: string) => {
-		const tokenUrl = `/oauth/login?socialType=K&authCode=${authCode}`;
-		//TODO: firstVisit대신 나중에 백엔드에서 DB 보냄
-		const firstVisit = localStorage.getItem("First visit");
-		try {
-			const response = await axiosInstance.post(tokenUrl);
-			if (response.status === 200) {
-				firstVisit === "false" && navigate("/");
-				navigate("/onboarding?step=CreateAccount");
-			}
-			// TODO: 나중에 수정 예정
-			if (response.status === 403) {
-				navigate("/");
-			}
-		} catch (error) {
-			console.error("error fetching access token:", error);
-		}
-	};
-
-	return <div></div>;
+	return <div />;
 }
 
 export default KakaoLoginPage;

--- a/src/pages/KakaoLoginPage.tsx
+++ b/src/pages/KakaoLoginPage.tsx
@@ -4,11 +4,16 @@ import { useSearchParams } from "react-router-dom";
 
 import axios from "axios";
 
+import { login } from "@/api/auth/authSlice";
+import { useAppDispatch } from "@/api/hooks";
+
 import { END_POINTS } from "@/constants/api";
 
 // 해당 페이지에서 이미 회원가입이 된 유저면 서버단에서는 현재 보이는 에러 페이지가 아니라 리다이렉트를 home으로 시켜줘야합니다.
 
 function KakaoLoginPage() {
+	const dispatch = useAppDispatch();
+
 	const navigate = useNavigate();
 
 	const [searchParams] = useSearchParams();
@@ -25,6 +30,8 @@ function KakaoLoginPage() {
 			);
 
 			if (response.status === 200) {
+				dispatch(login());
+
 				navigate("/onboarding?step=CreateAccount");
 			}
 
@@ -36,7 +43,7 @@ function KakaoLoginPage() {
 			// 에러날 가능성이 없지만 에러시 소셜 로그인 버튼 페이지로 이동
 			navigate("/onboarding?step=OauthSignUp");
 
-			console.error("error fetching access token:", error);
+			console.error(error);
 		}
 	};
 

--- a/src/pages/KakaoLoginPage.tsx
+++ b/src/pages/KakaoLoginPage.tsx
@@ -34,11 +34,6 @@ function KakaoLoginPage() {
 
 				navigate("/onboarding?step=CreateAccount");
 			}
-
-			// 불필요 코드 url이 서버단이기 때문에 어차피 작동을 안합니다 확인하시면 지워주세요
-			// if (response.status === 403) {
-			// 	navigate("/");
-			// }
 		} catch (error) {
 			// 에러날 가능성이 없지만 에러시 소셜 로그인 버튼 페이지로 이동
 			navigate("/onboarding?step=OauthSignUp");

--- a/src/pages/KakaoLoginPage.tsx
+++ b/src/pages/KakaoLoginPage.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+import { axiosInstance } from "@/api/axiosInstance";
+
+function KakaoLoginPage() {
+	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const authCode = searchParams.get("code");
+
+	useEffect(() => {
+		if (authCode !== null) {
+			fetchAccessToken(authCode);
+		}
+	}, [authCode]);
+
+	const fetchAccessToken = async (authCode: string) => {
+		const tokenUrl = `/oauth/login?socialType=K&authCode=${authCode}`;
+		//TODO: firstVisit대신 나중에 백엔드에서 DB 보냄
+		const firstVisit = localStorage.getItem("First visit");
+		try {
+			const response = await axiosInstance.post(tokenUrl);
+			if (response.status === 200) {
+				firstVisit === "false" && navigate("/");
+				navigate("/onboarding?step=CreateAccount");
+			}
+			// TODO: 나중에 수정 예정
+			if (response.status === 403) {
+				navigate("/");
+			}
+		} catch (error) {
+			console.error("error fetching access token:", error);
+		}
+	};
+
+	return <div></div>;
+}
+
+export default KakaoLoginPage;

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-// import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
 import CreateAccount from "@/components/Onboarding/CreateAccount/CreateAccount";
@@ -8,8 +7,17 @@ import SignUp from "@/components/Onboarding/SignUp/SignUp";
 import Splash from "@/components/Onboarding/Splash/Splash";
 import VisitorRoute from "@/components/Onboarding/VisitorRoute/VisitorRoute";
 
+import { useAppSelector } from "@/api/hooks";
+
 function OnboardingPage() {
+	const { isLogin } = useAppSelector((state) => state.auth);
+
+	console.log(isLogin);
+
+	// login 상태에서는 현재 페이지에 접근 시 home으로 리다이렉트해야합니다.
+
 	const navigate = useNavigate();
+
 	const [step, setStep] = useState<
 		"Splash" | "SignUp" | "OauthSignUp" | "CreateAccount" | "VisitorRoute" | string
 	>("Splash");

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 // import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
@@ -11,13 +11,21 @@ import VisitorRoute from "@/components/Onboarding/VisitorRoute/VisitorRoute";
 function OnboardingPage() {
 	const navigate = useNavigate();
 	const [step, setStep] = useState<
-		"Splash" | "SignUp" | "OauthSignUp" | "CreateAccount" | "VisitorRoute"
+		"Splash" | "SignUp" | "OauthSignUp" | "CreateAccount" | "VisitorRoute" | string
 	>("Splash");
 
-	//TODO: 테스트용 merge후 제거 예정
-	// VisitorRoute 빼고는 확인가능
-	// const user = useSelector((state) => state.user);
-	// console.log(user);
+	useEffect(() => {
+		const urlParams = new URLSearchParams(window.location.search);
+		const urlStep = urlParams.get("step");
+		if (urlStep) setStep(urlStep);
+	}, []);
+
+	useEffect(() => {
+		const firstVisit = localStorage.getItem("First visit");
+		if (firstVisit === "false" && step === "CreateAccount") {
+			navigate("/");
+		}
+	}, [step]);
 
 	return (
 		<main>

--- a/src/utils/getCookie.ts
+++ b/src/utils/getCookie.ts
@@ -1,0 +1,11 @@
+export const getCookie = (name: string) => {
+	const cookieArray = document.cookie.split(";"); // 쿠키들을 분리하여 배열로 만듦
+	for (let i = 0; i < cookieArray.length; i++) {
+		const cookiePair = cookieArray[i].split("="); // 키와 값을 분리
+		if (name == cookiePair[0].trim()) {
+			// 쿠키의 키 이름이 입력받은 이름과 일치하는지 확인
+			return decodeURIComponent(cookiePair[1]); // 쿠키의 값을 디코딩하여 반환
+		}
+	}
+	return null; // 일치하는 쿠키가 없다면 null 반환
+};


### PR DESCRIPTION
[TS-325](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109/backlog?assignee=712020%3A2697805c-34c2-4de5-99cb-4aab5f6d607a&selectedIssue=TS-325)

## 💡 변경사항 & 이슈
/onboarding kakao로그인시 로그인 완료
/onboarding -> /chatting 까지 다 끝내면 재로그인시 /onboarding 중간에 끝나게 설정
로그인만 하려면 http://localhost:3000/onboarding?step=OauthSignUp 로 리다이렉트 보내주세요
<br>

## ✍️ 관련 설명
- "dev": "vite --port 3000"
-> http://localhost:3000/oauth2/kakao URI로 AuthCode와 함께 redirect 보내야 한다고해서 3000번으로 설정했습니다.

- KakaoLoginPage 만든 이유
카카오로그인 인증 후에 http://13.209.65.59:8080/oauth/login?socialType=K&authCode=... 여기로 authCode를 보내서 <KakaoLoginPage / > 만들어서 /oauth/login으로 path하고
KakaoLoginPage에서 /onboarding?step=OauthSignUp 하도록 만들었습니다.

- oauth로그인시 /onboarding, /chatting 끝까지 해야되나?
/onboarding -> /chatting 까지 다 끝내면 로컬스토리지에 First Visit : false로 설정하여서 다시 로그인 시도시 /onboarding시에 로그인만 되면 home으로 가도록 하였습니다.




<br>

## ⭐️ Review point
변경되어야 할 코드
<br>

## 📷 Demo
<br>


[TS-325]: https://m2jun.atlassian.net/browse/TS-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ