### PR TITLE
[TS-358] Fix: 별자리 선택 후 모달 닫는 기능 추가

### DIFF
--- a/src/components/StarPage/Modal/SelectStarModal.tsx
+++ b/src/components/StarPage/Modal/SelectStarModal.tsx
@@ -21,6 +21,7 @@ export default function SelectStarModal() {
 	const handleFooterBtnClick = async () => {
 		try {
 			await dispatch(selectStar(id ?? "")).unwrap();
+			dispatch(closeModal());
 			navigate(PATH.STAR);
 		} catch (error) {
 			console.error(error);


### PR DESCRIPTION
[TS-358](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb)

## 💡 변경사항 & 이슈
별자리 선택 후 모달 닫는 기능 추가
<br>

## ✍️ 관련 설명
- star-card/:id에서 확인 가능
- 별자리 선택 후 선택한 별자리 상세 페이지에 재진입 시 모달이 계속 열려있음
- 해당 버그 해결하기위해 모달 닫는 코드 추가

<br>

## ⭐️ Review point
<br>

## 📷 Demo
### 수정 전

https://github.com/ConnectingStar/ConnectingStar-Front/assets/77181642/5c28c4b0-4376-4aec-9d1e-4b1cc0f5435c

### 수정 후 

https://github.com/ConnectingStar/ConnectingStar-Front/assets/77181642/847ac887-72b4-4bce-bb8b-f987822dad0d

<br>

[TS-358]: https://m2jun.atlassian.net/browse/TS-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ