### PR TITLE
[TS-360] 해금 모달 별 로티 애니메이션 추가

### DIFF
--- a/src/components/StarPage/Modal/CharacterUnlockModal.tsx
+++ b/src/components/StarPage/Modal/CharacterUnlockModal.tsx
@@ -5,7 +5,7 @@ import { css } from "@emotion/react";
 
 import { useLottie } from "lottie-react";
 
-import starBurstAnimation from "@/assets/lottie/lottie-star-burst-animation.json";
+import StarBurstAnimation from "@/assets/lottie/lottie-star-burst-animation.json";
 
 import FooterBtn from "@/components/common/FooterBtn/FooterBtn";
 import Modal from "@/components/common/Modal/Modal";
@@ -27,7 +27,7 @@ interface CharacterUnlockModalProps {
 }
 
 const options = {
-	animationData: starBurstAnimation,
+	animationData: StarBurstAnimation,
 	loop: false,
 };
 


### PR DESCRIPTION
[TS-360](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-360)

## 💡 변경사항 & 이슈
- 해금 모달 별 로티 애니메이션 추가
- 축하 문구 변경
<br>

## ✍️ 관련 설명
- /star 경로에서 해금 완료 시 등장
  - 참고: 세림님과 화면 공유 하면서 로티 애니메이션 위치를 맞춘거라 피그마 디자인에는 없습니다
- '축하합니다' 문구 뒤에 폭죽 아이콘 추가
  - 참고: 이 부분도 화면 공유 하면서 나온 의견이라 피그마 디자인에는 없습니다
  - 변경전: `축하합니다!` / 변경후: `축하합니다🎉`
<br>

## ⭐️ Review point
- 로티 애니메이션 이름 괜찮은지
- 그 외 이상한 부분 있는지

확인 부탁드립니다
<br>

## 📷 Demo

https://github.com/ConnectingStar/ConnectingStar-Front/assets/77181642/6425d7f2-d2d3-4bee-892f-4d88b1365a30


<br>


[TS-360]: https://m2jun.atlassian.net/browse/TS-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ