### PR TITLE
[TS-386] 바텀시트 체크박스 아이콘 안보이는 버그 픽스

### DIFF
--- a/src/components/common/Modal/CommonModal/SelectGenderModal/SelectGenderModal.style.ts
+++ b/src/components/common/Modal/CommonModal/SelectGenderModal/SelectGenderModal.style.ts
@@ -46,7 +46,7 @@ export const getCheckBoxLabelStyle = css`
 	input[type="radio"]:checked {
 		border: 1px solid ${theme.color.main_blue};
 		background-color: ${theme.color.main_blue};
-		background-image: url(${CheckIcon});
+		background-image: ${`url("${CheckIcon}")`};
 		background-repeat: no-repeat;
 		background-position: center;
 	}


### PR DESCRIPTION
[TS-386](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-386)

## 💡 변경사항 & 이슈
배포 환경에서 바텀시트 체크박스 아이콘이 안보이는 문제 수정했습니다

<img width="211" alt="스크린샷 2024-07-29 오후 3 43 20" src="https://github.com/user-attachments/assets/1bf81be7-d1ed-4c26-bea3-c65bd665e208">

<br>

## ✍️ 관련 설명
- vite 문서에서 url()을 통해 svg를 삽입할때는 변수를 큰따옴표로 감싸야 한다고 합니다 ([참고](https://ko.vitejs.dev/guide/assets))
- Deploy Preview를 통해 url에 아이콘 삽입되는 것 확인 했습니다
<br>

## ⭐️ Review point
<br>

## 📷 Demo
<br>


[TS-386]: https://m2jun.atlassian.net/browse/TS-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ