### PR TITLE
[TS-384] 온보딩 채팅 문구, 폰트 스타일 수정 & 조사(을/를) 적용

### DIFF
--- a/src/components/Chatting/ChattingMessage/ChattingMessage.style.ts
+++ b/src/components/Chatting/ChattingMessage/ChattingMessage.style.ts
@@ -13,6 +13,14 @@ export const container = css`
 		margin-right: 0.375rem;
 		background-color: #d9d9d9;
 	}
+
+	.bold {
+		${theme.font.body_b_bold}
+	}
+
+	.blue {
+		color: ${theme.color.main_blue};
+	}
 `;
 
 export const chatWrap = css`
@@ -55,9 +63,6 @@ export const userMessageStyle = css`
 			flex-direction: column;
 			gap: 0.75rem;
 		}
-		.bold {
-			${theme.font.body_b_bold}
-		}
 	}
 	.allUserData {
 		width: 13.125rem;
@@ -73,14 +78,12 @@ export const userMessageStyle = css`
 				gap: 6px;
 			}
 		}
-		.bold {
-			${theme.font.body_b_bold}
-		}
 		::after {
 			width: 100%;
 			height: 1px;
 			content: "";
 			background-color: white;
+			opacity: 0.3;
 			margin: 0.75rem 0;
 		}
 		&:last-of-type {

--- a/src/components/StarPage/Modal/CharacterUnlockModal.tsx
+++ b/src/components/StarPage/Modal/CharacterUnlockModal.tsx
@@ -18,7 +18,7 @@ import { PATH } from "@/constants/path";
 
 import { theme } from "@/styles/theme";
 
-import { josaIga } from "@/utils/starUtils";
+import { josaIga } from "@/utils/josa";
 
 interface CharacterUnlockModalProps {
 	id: number;

--- a/src/constants/chatData.tsx
+++ b/src/constants/chatData.tsx
@@ -173,7 +173,7 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		{
 			id: "inform",
 			botMessage: [
-				`마지막으로 습관 형성에 중요한 <span class="bold blue">두 가지 주의 사항</span>을 말씀드릴게요`,
+				`마지막으로 습관 형성에 중요한 <span class="bold">두 가지 주의 사항</span>을 말씀드릴게요`,
 				`<span class="bold blue">첫째,</span> 시간/장소/정도에 너무 얽매이지 마세요🙅 물론 지키면 좋지만, 중요한 건 <span class="bold blue">일단 하는 거</span>니까요`,
 				`<span class="bold blue">둘째,</span> 실천했든 쉬었든 그날의 기록을 남겨 주세요📝 <span class="bold blue">기록은 그 자체로 강력한 동기부여 수단</span>이 된답니다`,
 			],

--- a/src/constants/chatData.tsx
+++ b/src/constants/chatData.tsx
@@ -1,5 +1,7 @@
 import { modalType } from "@/constants/modalConstants";
 
+import { josaEulReul } from "@/utils/josa";
+
 import type { HabitRequestType } from "@/types/habit";
 
 export function createChatData(habitRequest: HabitRequestType, nickname?: string) {
@@ -19,8 +21,7 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 			id: "behavior",
 			botMessage: [
 				`좋아요, 이번엔 정체성을 정해 보죠`,
-				// TODO: 조사 을를 적용
-				`${habitRequest.behavior}를 통해 ${nickname}님은 어떤 사람이 되고 싶으세요?`,
+				`${habitRequest.behavior}${josaEulReul(habitRequest.behavior)} 통해 ${nickname}님은 어떤 사람이 되고 싶으세요?`,
 			],
 			bottomButton: ["정체성 선택"],
 			userMessage: `${habitRequest.identity}`,
@@ -58,9 +59,8 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		},
 		{
 			id: "place",
-			// TODO: 조사 을를 적용
 			botMessage: [
-				`이번엔 장소를 정해 볼게요🧭 ${habitRequest.behavior}를 쉽게 할 수 있거나 가는 것만으로 기분이 좋아지는 곳이 있나요?`,
+				`이번엔 장소를 정해 볼게요🧭 ${habitRequest.behavior}${josaEulReul(habitRequest.behavior)} 쉽게 할 수 있거나 가는 것만으로 기분이 좋아지는 곳이 있나요?`,
 			],
 			bottomButton: ["장소 선택"],
 			userMessage: `${habitRequest.place}`,
@@ -70,8 +70,7 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		{
 			id: "behaviorUnit",
 			botMessage: [
-				// TODO: 조사 을를 적용
-				`다음으로 ${habitRequest.behavior}를 얼마나 할지 정해 보겠습니다🚩 이때, 가능한 쉬운 수준으로 시작해 보세요`,
+				`다음으로 ${habitRequest.behavior}${josaEulReul(habitRequest.behavior)} 얼마나 할지 정해 보겠습니다🚩 이때, 가능한 쉬운 수준으로 시작해 보세요`,
 				`그러다 일주일 내내 실천할 수 있게 될 때쯤, 난이도를 살짝 높이고 주기적으로 수준을 높여가는 거예요😉`,
 			],
 			bottomButton: ["실천 정도 선택"],

--- a/src/constants/chatData.tsx
+++ b/src/constants/chatData.tsx
@@ -1,7 +1,5 @@
 import { modalType } from "@/constants/modalConstants";
 
-import { theme } from "@/styles/theme";
-
 import type { HabitRequestType } from "@/types/habit";
 
 export function createChatData(habitRequest: HabitRequestType, nickname?: string) {
@@ -9,9 +7,9 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		{
 			id: "firstMeet",
 			botMessage: [
-				`반가워요 ${nickname}님!\n저는 약속 맺기를 도울 타스예요 :)`,
-				`어떤 습관을 함께 만들어 볼까요?`,
-				`매일 해도 무리 없는 쉬운 것부터 시작하기를 추천해요 😊`,
+				`반갑습니다🙂 저는 ${nickname}님의 습관 설계를 도와드릴 타스라고 해요`,
+				`무엇을 우리의 첫 약속으로 시작해 볼까요?`,
+				`처음엔 매일 해도 무리 없는 쉬운 것부터 시작하는 게 좋아요😊`,
 			],
 			bottomButton: ["습관 선택"],
 			userMessage: `${habitRequest.behavior}`,
@@ -20,9 +18,9 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		{
 			id: "behavior",
 			botMessage: [
-				`그렇군요!`,
-				`이번엔 정체성을 정해 볼게요`,
-				`${habitRequest.behavior}을(를) 통해서 ${nickname}님은 어떤 사람이 되고 싶으세요?`,
+				`좋아요, 이번엔 정체성을 정해 보죠`,
+				// TODO: 조사 을를 적용
+				`${habitRequest.behavior}를 통해 ${nickname}님은 어떤 사람이 되고 싶으세요?`,
 			],
 			bottomButton: ["정체성 선택"],
 			userMessage: `${habitRequest.identity}`,
@@ -31,31 +29,28 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		{
 			id: "identity",
 			botMessage: [
-				`좋습니다 :)`,
-				`지금 이 순간부터 ${nickname}님은 ${habitRequest.identity} 사람이에요`,
-				`오늘부터 진심으로 ${nickname}님은 ${habitRequest.identity} 사람이라고 믿어 주세요!`,
+				`좋습니다, 지금 이 순간부터 ${nickname}님은 ${habitRequest.identity} 사람이라고 믿는 거예요💪`,
 			],
-			bottomButton: ["그런데 정체성을 왜 정하는 거야?"],
-			userMessage: "그런데 정체성을 왜 정하는 거야?",
+			bottomButton: ["그런데 정체성은 갑자기 왜?"],
+			userMessage: "그런데 정체성은 갑자기 왜?",
 		},
 		{
 			id: "reasonIdentity",
 			botMessage: [
-				`정체성을 정함으로써 스스로에게 믿음을 부여할 수 있어요`,
-				`그리고 우리는 놀랍도록 스스로가 믿는 대로 행동하죠`,
+				`우리는 놀라울 정도로 스스로가 믿는대로 행동하고 또 그렇게 변화하기 때문이에요`,
+				`처음엔 조금 어색하겠지만, 믿음이 쌓여가는 하루가 늘어갈 수록 어느새 믿는 대로 변화한 ${nickname}님의 모습에 놀라게 될 거예요🙂️`,
 			],
-			bottomButton: ["알겠어!"],
-			userMessage: "알겠어!",
+			bottomButton: ["좋아,  믿어볼게💪"],
+			userMessage: "좋아,  믿어볼게💪",
 		},
 		{
 			id: "runTime",
 			botMessage: [
-				`이제 본격적으로 습관을 구체화 시켜볼까요?`,
-				`습관 약속은 시간, 장소, 행동으로 구분돼요`,
-				`그리고 그 약속은\n1. 무엇을 할지 <span style="color: ${theme.color.main_blue};font-weight: 700;">명확</span>해야 하고\n2. 하고 싶도록 <span style="color: ${theme.color.main_blue};font-weight: 700;">매력</span>적이며\n3. <span style="color: ${theme.color.main_blue};font-weight: 700;">쉽게</span> 할 수 있어야 하고\n4. 하고 난 뒤 <span style="color: ${theme.color.main_blue};font-weight: 700;">만족</span>스러워야 합니다`,
-				`최대한 4가지 원칙에 맞게끔 습관을 만들어 볼까요?`,
-				`먼저 시간을 정해 볼게요!`,
-				`다른 일에 방해 받지 않는 시간 혹은 매일 지키기에 수월한 시간으로 설정해 주세요`,
+				`지금부터 습관 약속을 본격적으로 구체화 시켜볼게요`,
+				`먼저, 약속은 시간/장소/행동 세 가지 요소로 구분됩니다`,
+				`그리고 아래의 네 규칙을 지킬 수록 강력한 변화를 이끌어 낼 거예요`,
+				`1. <span class="bold blue">명확</span>할 것\n2. <span class="bold blue">매력</span>적일 것\n3. <span class="bold blue">쉬울</span> 것\n4. <span class="bold blue">만족</span>스러울 것`,
+				`시간부터 정해 볼게요⏰ 매일 지키기 쉽고 다른 일에 방해 받지 않는 시간은 언제인가요?`,
 			],
 			bottomButton: ["시간 선택"],
 			userMessage: `${habitRequest.runTime.noon} ${habitRequest.runTime.hour}:${habitRequest.runTime.minute}`,
@@ -63,10 +58,9 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		},
 		{
 			id: "place",
+			// TODO: 조사 을를 적용
 			botMessage: [
-				`다음으로 장소를 정해 볼게요!`,
-				`어떤 장소가 ${nickname}님에게 매력적인가요?`,
-				`가는 것만으로 만족스럽거나 습관을 쉽게 할 수 있는 곳으로 명확하게 적어 주세요`,
+				`이번엔 장소를 정해 볼게요🧭 ${habitRequest.behavior}를 쉽게 할 수 있거나 가는 것만으로 기분이 좋아지는 곳이 있나요?`,
 			],
 			bottomButton: ["장소 선택"],
 			userMessage: `${habitRequest.place}`,
@@ -76,10 +70,9 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		{
 			id: "behaviorUnit",
 			botMessage: [
-				`마지막으로 행동을 정해 볼게요`,
-				`난이도는 매일 할 수 있을 정도로 쉽게 시작해야 해요!`,
-				`예를들어 책을 읽는다면 30분보다 3장 처럼요 :D`,
-				`3장으로 시작했지만, 점차 자리 잡으면 30장도 쉬운 일이 되어 있을 거예요!`,
+				// TODO: 조사 을를 적용
+				`다음으로 ${habitRequest.behavior}를 얼마나 할지 정해 보겠습니다🚩 이때, 가능한 쉬운 수준으로 시작해 보세요`,
+				`그러다 일주일 내내 실천할 수 있게 될 때쯤, 난이도를 살짝 높이고 주기적으로 수준을 높여가는 거예요😉`,
 			],
 			bottomButton: ["실천 정도 선택"],
 			userMessage: `${habitRequest.behaviorValue} ${habitRequest.behaviorUnit}`,
@@ -87,7 +80,10 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		},
 		{
 			id: "alert",
-			botMessage: [`약속을 기억하고 실천을 기록하실 수 있도록 하루 두 번, 알림을 보내드릴게요!`],
+			botMessage: [
+				`좋습니다! 마지막으로 알림 받을 시간을 선택해 주세요☺️`,
+				`약속을 기억하고 실천을 기록할 수 있게 하루 두 번, 알림을 보내드립니다`,
+			],
 			bottomButton: ["이대로 진행", "1차 알림 변경", "2차 알림 변경"],
 			userMessage: `
 			<div class="alert">
@@ -107,7 +103,9 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		},
 		{
 			id: "organize",
-			botMessage: [`지금까지 나눈 이야기를 정리해 보여드릴게요`],
+			botMessage: [
+				`이제 거의 다 왔어요! 지금까지 나눈 이야기들을  정리해 보여드릴게요😊 수정할 부분이 있나요?`,
+			],
 			bottomButton: [
 				"이 내용이 맞아",
 				"정체성 변경",
@@ -176,23 +174,21 @@ export function createChatData(habitRequest: HabitRequestType, nickname?: string
 		{
 			id: "inform",
 			botMessage: [
-				`습관 실천이 가장 핵심이지만, 기록 역시 정말 중요해요 :)`,
-				`무엇 때문에 쉬었는지 혹은 오늘 실천은 어땠는지 매일 제게 알려주세요!`,
+				`마지막으로 습관 형성에 중요한 <span class="bold blue">두 가지 주의 사항</span>을 말씀드릴게요`,
+				`<span class="bold blue">첫째,</span> 시간/장소/정도에 너무 얽매이지 마세요🙅 물론 지키면 좋지만, 중요한 건 <span class="bold blue">일단 하는 거</span>니까요`,
+				`<span class="bold blue">둘째,</span> 실천했든 쉬었든 그날의 기록을 남겨 주세요📝 <span class="bold blue">기록은 그 자체로 강력한 동기부여 수단</span>이 된답니다`,
 			],
-			bottomButton: ["알겠어!"],
-			userMessage: "알겠어!",
+			bottomButton: ["기억할게, 일단 하기랑 기록 남기기 맞지?"],
+			userMessage: "기억할게, 일단 하기랑 기록 남기기 맞지?",
 		},
 		{
 			id: "last",
 			botMessage: [
-				`감사합니다. 실천을 기록하신 날에는 별을 드릴게요🌟`,
-				`모은 별로  별자리를 완성시킬 때마다 캐릭터를 획득할 수 있어요 :)`,
-				`성운 마을의 귀여운 친구들이 ${nickname}님과 만날 날을 기다리고 있답니다 :D`,
-				`Tars와 맺는 습관 약속은 <span style="color: ${theme.color.main_blue};font-weight: 700;">매일 실행</span>하는 것을 권장하고 있어요`,
-				`매번 완벽할 필요 없습니다`,
-				`약속의 단 10%만 지켜지더라도 \n<span style="color: ${theme.color.main_blue};font-weight: 700;">"꾸준하게 하는 것”</span>이 핵심이니까요`,
-				`고생 많으셨습니다!`,
-				`${habitRequest.behavior}를 꾸준히 하는 ${nickname}님을 응원할게요 XD`,
+				`네 맞아요, 감사합니다😊 그리고 그거 아세요?`,
+				`저 뿐만 아니라 다른 친구들도 ${nickname}님을 보고싶어 한다는 사실! `,
+				`하지만 부끄러움이 많아 별자리 뒤에 숨어 있답니다🫣`,
+				`<span class="bold">실천 기록으로 받은 별</span>을 별자리에 하나 둘 넣다 보면 어느새 친구들이 가득하게 될 거예요😉`,
+				`<span class="bold blue">스스로를 믿으며 꾸준히 나아갈</span> ${nickname}님을 응원하겠습니다💪 앞으로 잘 부탁드려요!`,
 			],
 			bottomButton: ["나도 잘 부탁해!"],
 			userMessage: "",

--- a/src/constants/starPageConstants.ts
+++ b/src/constants/starPageConstants.ts
@@ -32,6 +32,3 @@ export const STAR_DETAIL_STATUS = {
 } as const;
 
 export const TOGGLE_KEY = "have";
-
-export const HANGUL_START_CHARCODE = "가".charCodeAt(0);
-export const JONGSUNG = 28;

--- a/src/utils/josa.ts
+++ b/src/utils/josa.ts
@@ -1,0 +1,24 @@
+const HANGUL_START_CHARCODE = "가".charCodeAt(0);
+const HANGUL_END_CHARCODE = "힣".charCodeAt(0);
+const JONGSUNG = 28;
+
+/**
+ * 단어 마지막 글자의 종성(=받침) 유무 판단하는 함수
+ * @description 빈 문자열이거나 마지막 글자가 한글이 아니면 종성 유무를 제대로 판단하지 못하니 undefined 리턴
+ */
+function hasJongsung(letter: string) {
+	if (!letter) return;
+
+	const lastCharCode = letter.charCodeAt(letter.length - 1);
+	const isHangul = HANGUL_START_CHARCODE <= lastCharCode && lastCharCode <= HANGUL_END_CHARCODE;
+
+	if (!isHangul) return;
+
+	const jongsungIndex = (lastCharCode - HANGUL_START_CHARCODE) % JONGSUNG;
+
+	return jongsungIndex ? true : false;
+}
+
+export function josaIga(letter: string) {
+	return hasJongsung(letter) ? "이" : "가";
+}

--- a/src/utils/josa.ts
+++ b/src/utils/josa.ts
@@ -22,3 +22,7 @@ function hasJongsung(letter: string) {
 export function josaIga(letter: string) {
 	return hasJongsung(letter) ? "이" : "가";
 }
+
+export function josaEulReul(letter: string) {
+	return hasJongsung(letter) ? "을" : "를";
+}

--- a/src/utils/starUtils.ts
+++ b/src/utils/starUtils.ts
@@ -1,6 +1,6 @@
 import { StarDetailStatus, StarCardStatus, CategoryType, Circle } from "@/types/star";
 
-import { STAR_DETAIL_STATUS, HANGUL_START_CHARCODE, JONGSUNG } from "@/constants/starPageConstants";
+import { STAR_DETAIL_STATUS } from "@/constants/starPageConstants";
 
 export function generateStars() {
 	const stars = [];
@@ -44,11 +44,4 @@ export function validateToggleParams(param: string | null) {
 
 export function findCircleIndex(arr: Circle[]) {
 	return arr.findIndex((item) => item.filled === false);
-}
-
-export function josaIga(letter: string) {
-	if (!letter) return;
-	const lastCharCode = letter.charCodeAt(letter.length - 1);
-	const jongsungIndex = (lastCharCode - HANGUL_START_CHARCODE) % JONGSUNG;
-	return jongsungIndex ? "이" : "가";
 }


### PR DESCRIPTION
[TS-384](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-384)

## 💡 변경사항 & 이슈
한 브랜치에서 전부 변경하면 복잡할 것 같아 나눠서 작업했습니다
이 브랜치에서는 채팅 문구 관련 작업을 했습니다(문구 변경, 폰트 스타일 변경, 조사)
- 온보딩 채팅 문구 변경
- 폰트 스타일 수정
- 조사 을/를 적용
- 유저가 보낸 채팅 메시지 구분선 투명도 추가
<br>

## ✍️ 관련 설명
- /onboarding/habit 에서 확인 
- 온보딩 채팅 문구 변경했습니다(변경된 문구는 Figma 온보딩 채팅 파트 [제일 오른쪽 끝](https://www.figma.com/design/deVOGLOqzbCjKJP9fDeB3i/%ED%95%B4%EB%B9%97%EB%B2%84%EB%94%94?node-id=11734-17387&t=J0grR5VqgKFfr0LG-0)에서 확인할 수 있습니다)
- 폰트 스타일 수정했습니다(볼드, 볼드 + 파란색)
  - 똑같은 스타일이 계속 반복되어서 기존 인라인 스타일에서 class로 변경했습니다
- 조사 함수
  - 조사 을/를 함수(josaEulReul) 추가했습니다
  - 기존 이/가 함수(josaIga)와 동일한 로직을 hasJongsung 함수로 분리했습니다(종성 유무 판단)
  - 처리 해야하는 조사가 을/를/이/가 밖에 없어서 일단 josaEulReul 함수를 따로 만들었습니다
  - 별자리, 온보딩 두 곳에서 사용중이고 관련있는 코드는 한 곳에 모아두는게 좋을 것 같아 utils/josa.ts 파일로 옮겼습니다
<br>

## ⭐️ Review point
- 채팅 문구에서 오타나 누락된 부분 없는지
- 조사는 잘 적용 되는지

확인 부탁드립니다
<br>

## 📷 Demo
유저 채팅 메시지 구분선 변경
|변경 전|변경 후|
|---|---|
|<img width="245" alt="스크린샷 2024-08-08 오후 5 32 34" src="https://github.com/user-attachments/assets/5aa3eac2-9754-41f1-8ac7-34140c6ebb20">|<img width="245" alt="스크린샷 2024-08-08 오후 5 36 36" src="https://github.com/user-attachments/assets/90336a9f-5867-49c9-b95c-8483543f904a">|
<br>


[TS-384]: https://m2jun.atlassian.net/browse/TS-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ