### PR TITLE
[TS-391] 온보딩 채팅 페이지, 헤더 스타일 변경                                                                                                                                                                                                                                                                                                                                      

### DIFF
--- a/src/components/common/Header/Header.style.ts
+++ b/src/components/common/Header/Header.style.ts
@@ -6,15 +6,25 @@ export const getContainerStyle = (isFixed: boolean) => css`
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 22.5rem;
+	width: 100%;
 	height: 3.5rem;
-	padding: 0 1.5rem;
-	margin: 0 auto;
+	max-width: 500px; // TODO: globalStyle max-width와 동일(추후 600으로 변경 필요)
 	background-color: #fff;
 	z-index: ${theme.zIndex.overlayBottom};
-	position: ${isFixed ? "fixed" : "relative"};
+	position: ${isFixed && "fixed"};
 	left: ${isFixed && "50%"};
 	transform: ${isFixed && "translateX(-50%)"};
+`;
+
+export const innerContainerStyle = css`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	max-width: 22.5rem;
+	padding: 0 1.5rem;
+	position: relative;
 `;
 
 export const getTitleStyle = (hasButton: boolean) => css`

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -8,6 +8,7 @@ import { HeaderProps, TitleProps, IconButtonProps } from "@/types/headerType";
 
 import {
 	getContainerStyle,
+	innerContainerStyle,
 	getTitleStyle,
 	iconButtonStyle,
 	textButtonStyle,
@@ -18,7 +19,11 @@ import {
  */
 
 export default function Header({ children, isFixed = true }: HeaderProps) {
-	return <div css={getContainerStyle(isFixed)}>{children}</div>;
+	return (
+		<div css={getContainerStyle(isFixed)}>
+			<div css={innerContainerStyle}>{children}</div>
+		</div>
+	);
 }
 
 Header.Title = function HeaderTitle({ children, hasButton = true }: TitleProps) {

--- a/src/pages/OnboardingHabitPage.tsx
+++ b/src/pages/OnboardingHabitPage.tsx
@@ -131,7 +131,7 @@ export default OnboardingHabitPage;
 
 const containerStyle = css`
 	width: 100%;
-	max-width: 31.25rem; // TODO: globalStyle max-width와 동일(추후 600으로 변경 필요)
+	max-width: 500px; // TODO: globalStyle max-width와 동일(추후 600으로 변경 필요)
 	background-color: ${theme.color.bg};
 `;
 
@@ -148,7 +148,7 @@ const progressStyle = css`
 	left: 50%;
 	transform: translateX(-50%);
 	width: 100%;
-	max-width: 31.25rem;
+	max-width: 500px; // TODO: globalStyle max-width와 동일(추후 600으로 변경 필요)
 	padding-top: 3.5rem;
 	appearance: none;
 	::-webkit-progress-bar {

--- a/src/pages/OnboardingHabitPage.tsx
+++ b/src/pages/OnboardingHabitPage.tsx
@@ -47,19 +47,21 @@ const OnboardingHabitPage = () => {
 
 			<progress css={progressStyle} value={progress + 1} max={11} />
 
-			<div css={wrap(isExtraBtn)}>
-				{chatData &&
-					chatData
-						.slice(0, progress + 1)
-						.map((chatData) => (
-							<ChattingMessage
-								key={chatData.id}
-								chatData={chatData}
-								progress={progress}
-								addProgress={() => setProgress((prev) => prev + 1)}
-								handleSubmit={handleSubmit}
-							/>
-						))}
+			<div css={containerStyle}>
+				<div css={wrap(isExtraBtn)}>
+					{chatData &&
+						chatData
+							.slice(0, progress + 1)
+							.map((chatData) => (
+								<ChattingMessage
+									key={chatData.id}
+									chatData={chatData}
+									progress={progress}
+									addProgress={() => setProgress((prev) => prev + 1)}
+									handleSubmit={handleSubmit}
+								/>
+							))}
+				</div>
 			</div>
 
 			{modal === modalType.SELECT_BEHAVIOR && (
@@ -127,12 +129,17 @@ const OnboardingHabitPage = () => {
 
 export default OnboardingHabitPage;
 
+const containerStyle = css`
+	width: 100%;
+	max-width: 31.25rem; // TODO: globalStyle max-width와 동일(추후 600으로 변경 필요)
+	background-color: ${theme.color.bg};
+`;
+
 const wrap = (isExtraBtn?: boolean) => css`
 	max-width: 22.5rem;
 	min-height: 100vh;
 	padding: 5.75rem 1.5rem ${isExtraBtn ? "8.5rem" : "5.438rem"} 1.5rem;
 	margin: 0 auto;
-	background-color: ${theme.color.bg};
 	${theme.font.body_b};
 `;
 

--- a/src/pages/OnboardingHabitPage.tsx
+++ b/src/pages/OnboardingHabitPage.tsx
@@ -140,7 +140,8 @@ const progressStyle = css`
 	position: fixed;
 	left: 50%;
 	transform: translateX(-50%);
-	width: 22.5rem;
+	width: 100%;
+	max-width: 31.25rem;
 	padding-top: 3.5rem;
 	appearance: none;
 	::-webkit-progress-bar {


### PR DESCRIPTION
[TS-391](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-391)

## 💡 변경사항 & 이슈
- 온보딩 채팅 페이지 스타일 변경
- 헤더 스타일 변경
<br>

## ✍️ 관련 설명
/onboarding/habit 에서 확인 

### 온보딩 프로그레스 바, 채팅, 공통 헤더 스타일 변경
- 원래 온보딩 페이지 전체를 반응형으로 제작하기로 했으나 페이지 레이아웃이 깨져서 잘리는 부분만 변경했습니다 ([관련 논의 참고](https://discord.com/channels/1140589802517971055/1140818500080902184/1272540769223442467))
  - 헤더 배경, 프로그레스 바, 온보딩 채팅 배경이 잘려보여서 최대 가로 사이즈를 가득 채우게 변경
  - 내부 콘텐츠는 360px로 고정
  - 이에 따라 일부 컴포넌트 구조도 변경

### 최대 가로 사이즈
- 아직 반응형 디자인이 확정되지 않았고, 나중에 max-width가 변경될 수 있으니 우선은 500px로 설정했습니다 
- globalStyle과 단위를 동일하게 px로 설정했습니다

<br>

## ⭐️ Review point
헤더가 기존과 다르게 보이는 부분 없는지 확인 부탁드립니다 

<br>

## 📷 Demo
|이전|이후|
|---|---|
|<img width="500" alt="스크린샷 2024-08-14 오전 11 09 29" src="https://github.com/user-attachments/assets/e50f5e00-9a95-4bc9-afb2-f9493f845a9d">|<img width="500" alt="스크린샷 2024-08-14 오전 11 08 17" src="https://github.com/user-attachments/assets/4d87c79c-1e64-4d48-8b51-84c80558a5a7">|

<br>


[TS-391]: https://m2jun.atlassian.net/browse/TS-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ