### PR TITLE
[TS-395] 모바일 브라우저 pull to refresh 기능 막기

### DIFF
--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -26,6 +26,7 @@ export const GlobalStyle = css`
 	html,
 	body {
 		height: 100%;
+		overscroll-behavior-y: none;
 	}
 
 	img,


### PR DESCRIPTION
[TS-395](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-395)

## 💡 변경사항 & 이슈
모바일 브라우저 '당겨서 새로고침' 기능 막았습니다
<br>

## ✍️ 관련 설명
모바일 브라우저에서 당기는 제스쳐 해보시면 새로고침 기능이 막힌걸 확인할 수 있습니다 

### 참고
- `overscroll-behavior-y: contain`을 적용했을 때 ios와 안드로이드 간 동작이 일치하지 않는 문제가 있었습니다
- ios는 html에 `overscroll-behavior-y: none`을 적용해야 제대로 작동하고
안드로이드는 body에 `overscroll-behavior-y: none` 또는 `overscroll-behavior-y: contain`을 적용해야 제대로 작동합니다
- 그래서 기능을 통일시키기 위해 html, body 전부 `overscroll-behavior-y: none`을 적용했습니다
<br>

## ⭐️ Review point
<br>

## 📷 Demo

적용이 잘 되었다면 모바일 브라우저에서 페이지를 아래로 당겼을때 
사진에 있는 로딩 표시가 보이지 않습니다 

<img src="https://github.com/user-attachments/assets/389ce511-08d0-4952-9e16-d6c2e89611f0" width="360"/>



<br>


[TS-395]: https://m2jun.atlassian.net/browse/TS-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ