### PR TITLE
[TS-388] 프로필 이미지 설정, 별자리 선택 api v2로 변경

### DIFF
--- a/src/api/star/starSlice.ts
+++ b/src/api/star/starSlice.ts
@@ -2,7 +2,7 @@ import { StarDataType } from "@/types/star";
 import { createSlice } from "@reduxjs/toolkit";
 
 import { getStarMain, getStarDetail, getStarCard } from "@/api/star/starThunk";
-import { editProfileImage, addStar } from "@/api/user/userThunk";
+import { editProfileImageV2, addStar } from "@/api/user/userThunk";
 
 import { STAR_DETAIL_STATUS } from "@/constants/starPageConstants";
 
@@ -91,14 +91,14 @@ const starSlice = createSlice({
 			.addCase(getStarDetail.rejected, (state) => {
 				state.isLoading = false;
 			})
-			.addCase(editProfileImage.pending, (state) => {
+			.addCase(editProfileImageV2.pending, (state) => {
 				state.isLoading = true;
 			})
-			.addCase(editProfileImage.fulfilled, (state) => {
+			.addCase(editProfileImageV2.fulfilled, (state) => {
 				state.isLoading = false;
 				state.starDetail.isProfile = true;
 			})
-			.addCase(editProfileImage.rejected, (state) => {
+			.addCase(editProfileImageV2.rejected, (state) => {
 				state.isLoading = false;
 			})
 			.addCase(addStar.pending, (state) => {

--- a/src/api/user/userThunk.ts
+++ b/src/api/user/userThunk.ts
@@ -150,17 +150,6 @@ export const editProfileImageV2 = createAsyncThunk(
 	},
 );
 
-export const editProfileImage = createAsyncThunk(
-	"user/editProfileImage",
-	async (constellationId: string, thunkOptions) => {
-		try {
-			return await authorizedAxiosInstance.put(END_POINTS.USER_CONSTELLATION, { constellationId });
-		} catch (error) {
-			return thunkOptions.rejectWithValue(error);
-		}
-	},
-);
-
 export const selectStar = createAsyncThunk(
 	"user/selectStar",
 	async (constellationId: string, thunkOptions) => {

--- a/src/api/user/userThunk.ts
+++ b/src/api/user/userThunk.ts
@@ -136,7 +136,7 @@ export const editProfileImageV2 = createAsyncThunk(
 	"user/editProfileImageV2",
 	async ({ constellationId, related }: EditProfileImageRequestType, thunkOptions) => {
 		try {
-			const { data } = await authorizedAxiosInstance.patch(END_POINTS.USER_CONSTELLATION_V2, {
+			const { data } = await authorizedAxiosInstance.patch(END_POINTS.USER_PROFILE_CONSTELLATION, {
 				constellationId,
 				response: {
 					related: [related],

--- a/src/components/StarPage/Modal/SelectProfileImageModal.tsx
+++ b/src/components/StarPage/Modal/SelectProfileImageModal.tsx
@@ -7,7 +7,7 @@ import { layoutStyle } from "@/components/MyPage/Modal/LogoutModal";
 
 import { useAppDispatch } from "@/api/hooks";
 import { closeModal } from "@/api/modal/modalSlice";
-import { editProfileImage } from "@/api/user/userThunk";
+import { editProfileImageV2 } from "@/api/user/userThunk";
 
 import { useToast } from "@/hooks/useToast";
 
@@ -18,7 +18,12 @@ export default function SelectProfileImageModal() {
 
 	const handleFooterBtnClick = async () => {
 		try {
-			await dispatch(editProfileImage(id ?? "")).unwrap();
+			await dispatch(
+				editProfileImageV2({
+					constellationId: String(id),
+					related: "null",
+				}),
+			).unwrap();
 			dispatch(closeModal());
 			createToast("프로필 이미지로 설정했어요 😊");
 		} catch (error) {

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -30,7 +30,7 @@ export const END_POINTS = {
 		`constellation/list?constellationTypeId=${id}&isRegistered=${isRegistered}`,
 	STAR_DETAIL: (id: string) => `constellation?constellationId=${id}`,
 	USER_CONSTELLATION: "/v2/users/me/constellations",
-	USER_CONSTELLATION_V2: "/v2/users/me/profile-constellation",
+	USER_PROFILE_CONSTELLATION: "/v2/users/me/profile-constellation",
 	ADD_STAR: "user/constellation/star",
 };
 

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -29,7 +29,7 @@ export const END_POINTS = {
 	STAR_CARD: (id: string, isRegistered: boolean) =>
 		`constellation/list?constellationTypeId=${id}&isRegistered=${isRegistered}`,
 	STAR_DETAIL: (id: string) => `constellation?constellationId=${id}`,
-	USER_CONSTELLATION: "/user/constellation",
+	USER_CONSTELLATION: "/v2/users/me/constellations",
 	USER_CONSTELLATION_V2: "/v2/users/me/profile-constellation",
 	ADD_STAR: "user/constellation/star",
 };


### PR DESCRIPTION
[TS-388](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-388)

## 💡 변경사항 & 이슈
프로필 이미지 설정, 별자리 선택 api v2로 변경
<br>

## ✍️ 관련 설명
- /star-card/:id 에서 테스트 가능
- 별자리 상세 페이지에서 1) 프로필 이미지 선택, 2) 해금할 별자리 선택할 때 필요한 api를 v2로 변경
  - `POST 내 별자리 추가 (진행중인 별자리 등록)` 반영
  - `PATCH 내가 선택한 별자리 변경` 반영
<br>

## ⭐️ Review point
- 해당 기능 잘 동작하는지 확인 부탁드립니다 
- USER_CONSTELLATION_V2 엔드포인트가 변경되었으니 USER_PROFILE_CONSTELLATION으로 바꾸는건 어떻게 생각하시나요? 
<br>

## 📷 Demo
<br>


[TS-388]: https://m2jun.atlassian.net/browse/TS-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ