### PR TITLE
[TS-415] 온보딩 수정사항 반영

### DIFF
--- a/src/components/Chatting/BehaviorModal.tsx
+++ b/src/components/Chatting/BehaviorModal.tsx
@@ -62,14 +62,15 @@ function BehaviorModal({
 						<h3>얼마나</h3>
 						<form>
 							<input
-								type="number"
+								type="search"
+								inputMode="decimal"
 								placeholder="숫자 입력"
 								autoFocus
 								value={value || ""}
 								onChange={(e) => setValue(Number(e.target.value))}
 							/>
 							<input
-								type="text"
+								type="search"
 								placeholder="단위 입력 (예: 페이지)"
 								value={unit}
 								onChange={(e) => setUnit(e.target.value)}
@@ -127,6 +128,13 @@ const wrap = css`
 			padding: 1rem;
 			::placeholder {
 				color: ${theme.color.button_deactivated};
+			}
+
+			::-webkit-search-decoration,
+			::-webkit-search-cancel-button,
+			::-webkit-search-results-button,
+			::-webkit-search-results-decoration {
+				display: none;
 			}
 		}
 

--- a/src/components/common/Modal/CommonModal/ChangeNicknameModal.tsx
+++ b/src/components/common/Modal/CommonModal/ChangeNicknameModal.tsx
@@ -55,6 +55,7 @@ const ChangeNicknameModal = ({ prevNickname, updateInputValue }: ChangeNicknameM
 			<div css={layoutStyle}>
 				<h1>닉네임을 입력해 주세요</h1>
 				<input
+					type="search"
 					placeholder="닉네임을 입력해 주세요"
 					value={nickname}
 					onChange={(e) => handleNicknameChange(e)}
@@ -101,6 +102,13 @@ const layoutStyle = css`
 		margin: 1.6875rem 0 0.5rem;
 		background-color: ${theme.color.bg};
 		color: ${theme.color.font_black};
+
+		::-webkit-search-decoration,
+		::-webkit-search-cancel-button,
+		::-webkit-search-results-button,
+		::-webkit-search-results-decoration {
+			display: none;
+		}
 	}
 
 	& > div {

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
@@ -61,7 +61,7 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 				</ul>
 				<input
 					css={locationInputStyle}
-					type="text"
+					type="search"
 					placeholder="직접입력"
 					maxLength={10}
 					value={place}

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
@@ -61,4 +61,11 @@ export const locationInputStyle = css`
 		background-color: ${theme.color.bg};
 		color: black;
 	}
+
+	::-webkit-search-decoration,
+	::-webkit-search-cancel-button,
+	::-webkit-search-results-button,
+	::-webkit-search-results-decoration {
+		display: none;
+	}
 `;

--- a/src/components/common/Modal/CommonModal/SelectTagModal/SelectTagModal.style.ts
+++ b/src/components/common/Modal/CommonModal/SelectTagModal/SelectTagModal.style.ts
@@ -57,6 +57,13 @@ export const tagStyle = (isInputFocus: boolean) => css`
 			background-color: ${theme.color.bg};
 			color: black;
 		}
+
+		::-webkit-search-decoration,
+		::-webkit-search-cancel-button,
+		::-webkit-search-results-button,
+		::-webkit-search-results-decoration {
+			display: none;
+		}
 	}
 
 	.selected {

--- a/src/components/common/Modal/CommonModal/SelectTagModal/SelectTagModal.tsx
+++ b/src/components/common/Modal/CommonModal/SelectTagModal/SelectTagModal.tsx
@@ -66,7 +66,7 @@ function SelectTagModal({
 			</Header>
 
 			<div css={wrap}>
-				<h1>{type === "action" ? "어떤 습관을 만들어 볼까요?" : "어떤 사람이 되고 싶으세요?"}</h1>
+				<h1>{type === "behavior" ? "어떤 습관을 만들어 볼까요?" : "어떤 사람이 되고 싶으세요?"}</h1>
 				<div css={tagStyle(isInputFocus)}>
 					<ul>
 						{tags.map((tag) => (

--- a/src/components/common/Modal/CommonModal/SelectTagModal/SelectTagModal.tsx
+++ b/src/components/common/Modal/CommonModal/SelectTagModal/SelectTagModal.tsx
@@ -80,7 +80,7 @@ function SelectTagModal({
 						))}
 					</ul>
 					<input
-						type="text"
+						type="search"
 						placeholder="직접입력"
 						maxLength={10}
 						className={!selectedTag && inputText !== "" ? "selected" : ""}

--- a/src/pages/SignUpPage/SignUpPage.style.ts
+++ b/src/pages/SignUpPage/SignUpPage.style.ts
@@ -7,8 +7,13 @@ export const layoutStyle = css`
 	justify-content: center;
 	width: 22.5rem;
 	height: 100dvh;
-	padding: 3.438rem 1.5rem 0;
+	padding: env(safe-area-inset-top) 1.5rem 0;
 	margin: 0 auto;
+
+	// NOTE: iOS PWA에서 dvh 단위 적용 시 하단 여백 생겨서 추가
+	@media (display-mode: standalone) {
+		height: 100vh;
+	}
 `;
 
 export const boxStyle = css`
@@ -17,11 +22,11 @@ export const boxStyle = css`
 	align-items: center;
 	justify-content: flex-end;
 	width: 100%;
-	margin-bottom: 6.875rem;
-	gap: 12.5rem;
+	margin-bottom: 10.125rem;
 
 	img[alt="logo"] {
 		width: 18.4375rem;
+		margin: auto 0;
 	}
 `;
 
@@ -52,7 +57,7 @@ export const buttonBoxStyle = css`
 
 export const privacyBoxStyle = css`
 	position: fixed;
-	bottom: 1.25rem;
+	bottom: 3.125rem;
 	display: flex;
 	flex-direction: column;
 	align-items: center;


### PR DESCRIPTION
[TS-415](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-415)

## 💡 변경사항 & 이슈
온보딩 페이지 수정사항 반영
- 온보딩 습관 행동 선택 시 헤더 문구 변경
- 모달에서 입력 시 키보드 영역으로 인해 확인 버튼 가려지는 문제 해결
- 로고 중앙 정렬
<br>

## ✍️ 관련 설명
### 모달에서 입력 시 키보드 영역으로 인해 확인 버튼 가려지는 문제
- 키보드 상단에 등장하는 자동 완성 영역은 안드로이드 크롬 브라우저에서만 등장했습니다
- 처음에는 스크롤을 상단으로 올려서 '확인' 버튼을 볼 수 있도록 구성했지만, 자동 완성 영역이 뒤늦게 등장하여 화면이 버벅이는 것처럼 보여서 이 방법은 쓰지 않았습니다
- 그래서 자동 완성 영역 자체를 제거하는 방향으로 진행했고, input type="search" 또는 textarea를 사용하는 방법이 있었습니다 (다른 타입에서는 자동 완성 영역이 생김)
- textarea를 사용했을때 기본 기능(resize, 엔터 눌렀을때 줄바꿈 등)을 막는게 번거로워서 현재 상황에서는 input type을 search로 바꾸는게 낫다고 판단했습니다
- input type을 search로 바꾸었을때 등장하는 기본 스타일이 있어서 이를 제거하는 코드를 추가했습니다
<br>

## ⭐️ Review point
누락된 부분이 있거나 다른 의견이 있으시면 말씀해 주세요
<br>

## 📷 Demo
|이전|이후|
|---|---|
|<img width="286" alt="스크린샷 2024-12-09 오후 4 22 45" src="https://github.com/user-attachments/assets/287691e7-e88c-4d52-be7c-cc2d1e8ccdd3">|<img width="286" alt="스크린샷 2024-12-09 오후 4 23 01" src="https://github.com/user-attachments/assets/ab534750-f6e4-4ca8-89d2-def63128c921">|

<br>

[TS-415]: https://m2jun.atlassian.net/browse/TS-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ