### PR TITLE
[TS-420] 푸시 알림 누르면 화면 열기

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -15,12 +15,16 @@ self.addEventListener("push", function (e) {
 	if (!e.data.json()) return;
 
 	const resultData = e.data.json().notification;
+	const notificationUrl = e.data.json().data.click_action;
 	const notificationTitle = resultData.title;
 
 	const notificationOptions = {
 		body: resultData.body,
 		icon: "/assets/icon-192.png",
 		badge: "/assets/android-notification-icon.png",
+		data: {
+			notificationUrl,
+		},
 	};
 
 	console.log(resultData.title, {
@@ -28,4 +32,32 @@ self.addEventListener("push", function (e) {
 	});
 
 	e.waitUntil(self.registration.showNotification(notificationTitle, notificationOptions));
+});
+
+self.addEventListener("notificationclick", (e) => {
+	e.notification.close();
+
+	const notificationUrl = new URL(e.notification.data.notificationUrl);
+
+	const focusOrOpenWindow = async () => {
+		const clientList = await clients.matchAll({
+			type: "window",
+			includeUncontrolled: true,
+		});
+
+		const matchingClient = clientList.find((client) => {
+			const clientUrl = new URL(client.url);
+			return clientUrl.origin === notificationUrl.origin;
+		});
+
+		if (!matchingClient) {
+			return clients.openWindow(notificationUrl);
+		}
+
+		if ("focus" in matchingClient) {
+			return matchingClient.focus();
+		}
+	};
+
+	e.waitUntil(focusOrOpenWindow());
 });


### PR DESCRIPTION
[TS-420](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-420)

## 💡 변경사항 & 이슈
푸시 알림 누르면 화면 여는 기능 추가
<br>

## ✍️ 관련 설명
**동작**
- origin이 동일한 창이 열려있으면 해당 창에 포커스
- origin이 동일한 창이 없다면 창 열기

**참고**
<img width="740" alt="스크린샷 2024-12-12 오후 10 54 07" src="https://github.com/user-attachments/assets/9674da94-6cae-4e67-b8d8-d9bfed70ca89" />
- 서버에서 전달하는 click_action을 기준으로 origin이 동일한지 판단합니다. 
- 모바일 PWA 환경에서는 제대로 테스트를 못해봐서 배포 후 제대로된 테스트가 가능할 것 같습니다. 
<br>

## ⭐️ Review point
<br>

## 📷 Demo
<br>


[TS-420]: https://m2jun.atlassian.net/browse/TS-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ