### PR TITLE
[TS-422] 온보딩 장소 입력 풀스크린 모달에서 가상 키보드 등장 시 모달 내용이 보이지 않는 문제 해결

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap" rel="stylesheet">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap" rel="stylesheet">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
@@ -6,7 +6,6 @@ import FooterBtn from "@/components/common/FooterBtn/FooterBtn";
 import Header from "@/components/common/Header/Header";
 import {
 	container,
-	wrapper,
 	contents,
 	locationListStyle,
 	locationInputStyle,
@@ -35,9 +34,6 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 	const [place, setPlace] = useState(prevValue ?? "");
 	const [isInputFocus, setIsInputFocus] = useState(false);
 
-	const [visualViewport, setVisualViewport] = useState(0);
-	const [visualViewportOffsetTop, setVisualViewportOffsetTop] = useState(0);
-
 	const modalRef = useRef<HTMLDivElement | null>(null);
 	const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -52,73 +48,56 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 	useEffect(() => {
 		document.body.style.overflow = "hidden";
 
-		const logVisualViewport = () => {
-			const visualViewport = window.visualViewport;
-
-			if (visualViewport === null) return;
-
-			const visualViewportHeight = visualViewport.height;
-			const visualViewportOffsetTop = visualViewport.offsetTop;
-
-			if (window.innerHeight > visualViewportHeight) {
-				setVisualViewportOffsetTop(visualViewportOffsetTop);
-				setVisualViewport(visualViewportHeight);
-				modalRef.current?.scrollTo(0, 1500);
-			} else {
-				setVisualViewportOffsetTop(0);
-				setVisualViewport(0);
-			}
+		const scrollModal = () => {
+			modalRef.current?.scrollTo(0, modalRef.current?.scrollHeight);
 		};
-		window.visualViewport?.addEventListener("resize", logVisualViewport);
-		window.visualViewport?.addEventListener("scroll", logVisualViewport);
+
+		window.visualViewport?.addEventListener("resize", scrollModal);
 
 		return () => {
 			document.body.style.overflow = "auto";
-			window.visualViewport?.removeEventListener("resize", logVisualViewport);
-			window.visualViewport?.removeEventListener("scroll", logVisualViewport);
+			window.visualViewport?.removeEventListener("resize", scrollModal);
 		};
-	}, [visualViewport, visualViewportOffsetTop]);
+	}, []);
 
 	return (
-		<div css={container}>
-			<div css={wrapper(visualViewport)} ref={modalRef}>
-				<Header>
-					<Header.CloseButton onClick={() => dispatch(closeModal())} />
-				</Header>
+		<div css={container} ref={modalRef}>
+			<Header>
+				<Header.CloseButton onClick={() => dispatch(closeModal())} />
+			</Header>
 
-				<div css={contents}>
-					<h1>장소를 입력해 주세요</h1>
-					<ul css={locationListStyle}>
-						<p>예시</p>
-						{locationModalData.map((example) => (
-							<li key={example}>
-								<CheckIcon />
-								{example}
-							</li>
-						))}
-					</ul>
-					<input
-						ref={inputRef}
-						css={locationInputStyle}
-						type="search"
-						placeholder="직접입력"
-						maxLength={10}
-						value={place}
-						onFocus={() => setIsInputFocus(true)}
-						onBlur={() => setIsInputFocus(false)}
-						onChange={(e) => setPlace(e.target.value)}
-					/>
-				</div>
-
-				<FooterBtn
-					text="확인"
-					isSquare={isInputFocus}
-					disabled={!place}
-					handleBtnClick={() => {
-						isInputFocus ? setIsInputFocus(false) : confirmSelectedTag();
-					}}
+			<div css={contents}>
+				<h1>장소를 입력해 주세요</h1>
+				<ul css={locationListStyle}>
+					<p>예시</p>
+					{locationModalData.map((example) => (
+						<li key={example}>
+							<CheckIcon />
+							{example}
+						</li>
+					))}
+				</ul>
+				<input
+					ref={inputRef}
+					css={locationInputStyle}
+					type="search"
+					placeholder="직접입력"
+					maxLength={10}
+					value={place}
+					onFocus={() => setIsInputFocus(true)}
+					onBlur={() => setIsInputFocus(false)}
+					onChange={(e) => setPlace(e.target.value)}
 				/>
 			</div>
+
+			<FooterBtn
+				text="확인"
+				isSquare={isInputFocus}
+				disabled={!place}
+				handleBtnClick={() => {
+					isInputFocus ? setIsInputFocus(false) : confirmSelectedTag();
+				}}
+			/>
 		</div>
 	);
 }

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
@@ -9,6 +9,7 @@ import {
 	contents,
 	locationListStyle,
 	locationInputStyle,
+	scroll,
 } from "@/components/common/Modal/CommonModal/LocationModal/LocationModalStyle";
 
 import { useAppDispatch } from "@/api/hooks";
@@ -46,7 +47,6 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 	};
 
 	useEffect(() => {
-		document.documentElement.style.overflow = "hidden";
 		document.body.style.overflow = "hidden";
 
 		const updateBottom = () => {
@@ -54,8 +54,7 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 
 			if (viewport === null) return;
 
-			// bottom 위치 계산 공식
-			const viewportBottom = window.innerHeight - (viewport.offsetTop + viewport.height);
+			const viewportBottom = window.innerHeight - viewport.height;
 
 			if (modalRef.current) {
 				modalRef.current.style.bottom = `${viewportBottom}px`;
@@ -71,7 +70,7 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 
 			if (modalRef.current) {
 				modalRef.current.style.height = `${viewportHeight}px`;
-				modalContentsRef.current?.scrollTo(0, 1500);
+				modalContentsRef.current?.scrollTo(0, viewportHeight);
 			}
 		};
 
@@ -85,7 +84,6 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 
 		return () => {
 			document.body.style.overflow = "auto";
-			document.documentElement.style.overflow = "auto";
 			window.visualViewport?.removeEventListener("resize", updateBottom);
 			window.visualViewport?.removeEventListener("scroll", updateBottom);
 		};
@@ -119,6 +117,7 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 					onChange={(e) => setPlace(e.target.value)}
 				/>
 			</div>
+			<div css={scroll}></div>
 
 			<FooterBtn
 				text="확인"

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
@@ -60,8 +60,6 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 			const visualViewportHeight = visualViewport.height;
 			const visualViewportOffsetTop = visualViewport.offsetTop;
 
-			modalRef.current?.scrollTo(0, 1500);
-
 			if (window.innerHeight > visualViewportHeight) {
 				setVisualViewportOffsetTop(visualViewportOffsetTop);
 				setVisualViewport(visualViewportHeight);

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
@@ -115,7 +115,13 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 					maxLength={10}
 					value={place}
 					onFocus={() => setIsInputFocus(true)}
-					onBlur={() => setIsInputFocus(false)}
+					onBlur={() => {
+						setIsInputFocus(false);
+						if (modalRef.current) {
+							modalRef.current.style.bottom = `${0}px`;
+							modalRef.current.style.height = "100dvh";
+						}
+					}}
 					onChange={(e) => setPlace(e.target.value)}
 				/>
 			</div>

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
@@ -35,6 +35,7 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 	const [isInputFocus, setIsInputFocus] = useState(false);
 
 	const modalRef = useRef<HTMLDivElement | null>(null);
+	const modalContentsRef = useRef<HTMLDivElement | null>(null);
 
 	const confirmSelectedTag = () => {
 		progress === 5 && addprogress && addprogress();
@@ -70,7 +71,7 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 
 			if (modalRef.current) {
 				modalRef.current.style.height = `${viewportHeight}px`;
-				modalRef.current.scrollTo(0, 1500);
+				modalContentsRef.current?.scrollTo(0, 1500);
 			}
 		};
 
@@ -96,7 +97,7 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 				<Header.CloseButton onClick={() => dispatch(closeModal())} />
 			</Header>
 
-			<div css={contents}>
+			<div css={contents} ref={modalContentsRef}>
 				<h1>장소를 입력해 주세요</h1>
 				<ul css={locationListStyle}>
 					<p>예시</p>

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 
 import CheckIcon from "@/assets/icon/ic-check-blue.svg?react";
 
@@ -6,7 +6,8 @@ import FooterBtn from "@/components/common/FooterBtn/FooterBtn";
 import Header from "@/components/common/Header/Header";
 import {
 	container,
-	wrap,
+	wrapper,
+	contents,
 	locationListStyle,
 	locationInputStyle,
 } from "@/components/common/Modal/CommonModal/LocationModal/LocationModalStyle";
@@ -34,6 +35,12 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 	const [place, setPlace] = useState(prevValue ?? "");
 	const [isInputFocus, setIsInputFocus] = useState(false);
 
+	const [visualViewport, setVisualViewport] = useState(0);
+	const [visualViewportOffsetTop, setVisualViewportOffsetTop] = useState(0);
+
+	const modalRef = useRef<HTMLDivElement | null>(null);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
 	const confirmSelectedTag = () => {
 		progress === 5 && addprogress && addprogress();
 
@@ -42,38 +49,72 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 		dispatch(closeModal());
 	};
 
+	useEffect(() => {
+		document.body.style.overflow = "hidden";
+
+		const logVisualViewport = () => {
+			const visualViewport = window.visualViewport;
+
+			if (visualViewport === null) return;
+
+			const visualViewportHeight = visualViewport.height;
+			const visualViewportOffsetTop = visualViewport.offsetTop;
+
+			modalRef.current?.scrollTo(0, 1500);
+
+			if (window.innerHeight > visualViewportHeight) {
+				setVisualViewportOffsetTop(visualViewportOffsetTop);
+				setVisualViewport(visualViewportHeight);
+				modalRef.current?.scrollTo(0, 1500);
+			} else {
+				setVisualViewportOffsetTop(0);
+				setVisualViewport(0);
+			}
+		};
+		window.visualViewport?.addEventListener("resize", logVisualViewport);
+		window.visualViewport?.addEventListener("scroll", logVisualViewport);
+
+		return () => {
+			document.body.style.overflow = "auto";
+			window.visualViewport?.removeEventListener("resize", logVisualViewport);
+			window.visualViewport?.removeEventListener("scroll", logVisualViewport);
+		};
+	}, [visualViewport, visualViewportOffsetTop]);
+
 	return (
 		<div css={container}>
-			<Header>
-				<Header.CloseButton onClick={() => dispatch(closeModal())} />
-			</Header>
+			<div css={wrapper(visualViewport)} ref={modalRef}>
+				<Header>
+					<Header.CloseButton onClick={() => dispatch(closeModal())} />
+				</Header>
 
-			<div css={wrap}>
-				<h1>장소를 입력해 주세요</h1>
-				<ul css={locationListStyle}>
-					<p>예시</p>
-					{locationModalData.map((example) => (
-						<li key={example}>
-							<CheckIcon />
-							{example}
-						</li>
-					))}
-				</ul>
-				<input
-					css={locationInputStyle}
-					type="search"
-					placeholder="직접입력"
-					maxLength={10}
-					value={place}
-					onFocus={() => setIsInputFocus(true)}
-					onBlur={() => setIsInputFocus(false)}
-					onChange={(e) => setPlace(e.target.value)}
-				/>
+				<div css={contents}>
+					<h1>장소를 입력해 주세요</h1>
+					<ul css={locationListStyle}>
+						<p>예시</p>
+						{locationModalData.map((example) => (
+							<li key={example}>
+								<CheckIcon />
+								{example}
+							</li>
+						))}
+					</ul>
+					<input
+						ref={inputRef}
+						css={locationInputStyle}
+						type="search"
+						placeholder="직접입력"
+						maxLength={10}
+						value={place}
+						onFocus={() => setIsInputFocus(true)}
+						onBlur={() => setIsInputFocus(false)}
+						onChange={(e) => setPlace(e.target.value)}
+					/>
+				</div>
 
 				<FooterBtn
 					text="확인"
 					isSquare={isInputFocus}
-					isTransparent
 					disabled={!place}
 					handleBtnClick={() => {
 						isInputFocus ? setIsInputFocus(false) : confirmSelectedTag();

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
@@ -35,7 +35,6 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 	const [isInputFocus, setIsInputFocus] = useState(false);
 
 	const modalRef = useRef<HTMLDivElement | null>(null);
-	const inputRef = useRef<HTMLInputElement | null>(null);
 
 	const confirmSelectedTag = () => {
 		progress === 5 && addprogress && addprogress();
@@ -46,17 +45,48 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 	};
 
 	useEffect(() => {
+		document.documentElement.style.overflow = "hidden";
 		document.body.style.overflow = "hidden";
 
-		const scrollModal = () => {
-			modalRef.current?.scrollTo(0, modalRef.current?.scrollHeight);
+		const updateBottom = () => {
+			const viewport = window.visualViewport;
+
+			if (viewport === null) return;
+
+			// bottom 위치 계산 공식
+			const viewportBottom = window.innerHeight - (viewport.offsetTop + viewport.height);
+
+			if (modalRef.current) {
+				modalRef.current.style.bottom = `${viewportBottom}px`;
+			}
 		};
 
-		window.visualViewport?.addEventListener("resize", scrollModal);
+		const updateHeight = () => {
+			const viewport = window.visualViewport;
+
+			if (viewport === null) return;
+
+			const viewportHeight = viewport.height;
+
+			if (modalRef.current) {
+				modalRef.current.style.height = `${viewportHeight}px`;
+				modalRef.current.scrollTo(0, 1500);
+			}
+		};
+
+		const handleUpdateViewport = () => {
+			updateHeight();
+			updateBottom();
+		};
+
+		window.visualViewport?.addEventListener("resize", handleUpdateViewport);
+		window.visualViewport?.addEventListener("scroll", handleUpdateViewport);
 
 		return () => {
 			document.body.style.overflow = "auto";
-			window.visualViewport?.removeEventListener("resize", scrollModal);
+			document.documentElement.style.overflow = "auto";
+			window.visualViewport?.removeEventListener("resize", updateBottom);
+			window.visualViewport?.removeEventListener("scroll", updateBottom);
 		};
 	}, []);
 
@@ -78,7 +108,6 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 					))}
 				</ul>
 				<input
-					ref={inputRef}
 					css={locationInputStyle}
 					type="search"
 					placeholder="직접입력"

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModal.tsx
@@ -47,6 +47,7 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 	};
 
 	useEffect(() => {
+		document.documentElement.style.overflow = "hidden"; // NOTE: iOS PWA 환경에서 필요
 		document.body.style.overflow = "hidden";
 
 		const updateBottom = () => {
@@ -83,6 +84,7 @@ function LocationModal({ progress, addprogress, prevValue, updateInputValue }: L
 		window.visualViewport?.addEventListener("scroll", handleUpdateViewport);
 
 		return () => {
+			document.documentElement.style.overflow = "auto";
 			document.body.style.overflow = "auto";
 			window.visualViewport?.removeEventListener("resize", updateBottom);
 			window.visualViewport?.removeEventListener("scroll", updateBottom);

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
@@ -12,7 +12,6 @@ export const container = css`
 	background-color: white;
 	z-index: ${theme.zIndex.overlayMiddle};
 	transform: translate(0, 0);
-	overscroll-behavior: contain;
 `;
 
 export const contents = css`

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
@@ -20,8 +20,8 @@ export const scroll = css`
 	width: 1px;
 	height: calc(100% + 1px);
 	position: absolute;
-	left: 0;
 	top: 0;
+	left: 0;
 `;
 
 export const contents = css`

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
@@ -12,6 +12,16 @@ export const container = css`
 	background-color: white;
 	z-index: ${theme.zIndex.overlayMiddle};
 	transform: translate(0, 0);
+	overflow-y: auto;
+	overscroll-behavior-y: none;
+`;
+
+export const scroll = css`
+	width: 1px;
+	height: calc(100% + 1px);
+	position: absolute;
+	left: 0;
+	top: 0;
 `;
 
 export const contents = css`

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
@@ -10,15 +10,7 @@ export const container = css`
 	height: 100vh;
 	background-color: white;
 	z-index: ${theme.zIndex.overlayMiddle};
-`;
-
-export const wrapper = (visualViewportHeight: number) => css`
-	position: fixed;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	height: ${visualViewportHeight ? `${visualViewportHeight}px` : "100%"};
-	overscroll-behavior: contain; // 스크롤 체이닝 방지
+	overscroll-behavior: contain;
 	overflow-y: auto;
 `;
 
@@ -69,7 +61,7 @@ export const locationInputStyle = css`
 		outline: none;
 		background-color: ${theme.color.bg};
 		color: black;
-		margin-bottom: 75px;
+		margin-bottom: 4.6875rem;
 	}
 
 	::-webkit-search-decoration,

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
@@ -16,14 +16,6 @@ export const container = css`
 	overscroll-behavior-y: none;
 `;
 
-export const scroll = css`
-	width: 1px;
-	height: calc(100% + 1px);
-	position: absolute;
-	top: 0;
-	left: 0;
-`;
-
 export const contents = css`
 	width: 22.5rem;
 	height: 100%;
@@ -83,4 +75,12 @@ export const locationInputStyle = css`
 	::-webkit-search-results-decoration {
 		display: none;
 	}
+`;
+
+export const scrollable = css`
+	width: 1px;
+	height: calc(100% + 1px);
+	position: absolute;
+	top: 0;
+	left: 0;
 `;

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
@@ -71,7 +71,6 @@ export const locationInputStyle = css`
 	}
 
 	&:focus {
-		position: relative;
 		outline: none;
 		background-color: ${theme.color.bg};
 		color: black;

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
@@ -4,20 +4,24 @@ import { theme } from "@/styles/theme";
 
 export const container = css`
 	position: fixed;
-	top: 0;
+	bottom: 0;
 	left: 0;
+	right: 0;
 	width: 100%;
-	height: 100vh;
+	height: 100dvh;
 	background-color: white;
 	z-index: ${theme.zIndex.overlayMiddle};
+	transform: translate(0, 0);
 	overscroll-behavior: contain;
-	overflow-y: auto;
 `;
 
 export const contents = css`
 	width: 22.5rem;
+	height: 100%;
 	padding: calc(4.75rem + env(safe-area-inset-top)) 1.5rem 0;
 	margin: 0 auto;
+	overflow-y: auto;
+
 	& > h1 {
 		margin-bottom: 2.5rem;
 		${theme.font.head_a}
@@ -58,6 +62,7 @@ export const locationInputStyle = css`
 	}
 
 	&:focus {
+		position: relative;
 		outline: none;
 		background-color: ${theme.color.bg};
 		color: black;

--- a/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
+++ b/src/components/common/Modal/CommonModal/LocationModal/LocationModalStyle.ts
@@ -11,9 +11,20 @@ export const container = css`
 	background-color: white;
 	z-index: ${theme.zIndex.overlayMiddle};
 `;
-export const wrap = css`
+
+export const wrapper = (visualViewportHeight: number) => css`
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	height: ${visualViewportHeight ? `${visualViewportHeight}px` : "100%"};
+	overscroll-behavior: contain; // 스크롤 체이닝 방지
+	overflow-y: auto;
+`;
+
+export const contents = css`
 	width: 22.5rem;
-	padding: calc(4.75rem + env(safe-area-inset-top)) 1.5rem;
+	padding: calc(4.75rem + env(safe-area-inset-top)) 1.5rem 0;
 	margin: 0 auto;
 	& > h1 {
 		margin-bottom: 2.5rem;
@@ -55,11 +66,10 @@ export const locationInputStyle = css`
 	}
 
 	&:focus {
-		position: fixed;
-		bottom: 4.688rem;
 		outline: none;
 		background-color: ${theme.color.bg};
 		color: black;
+		margin-bottom: 75px;
 	}
 
 	::-webkit-search-decoration,


### PR DESCRIPTION
[TS-422](https://m2jun.atlassian.net/jira/software/projects/TS/boards/109?assignee=616ccf7525f31300702d29cb&selectedIssue=TS-422)

## 💡 변경사항 & 이슈
온보딩 장소 입력 풀스크린 모달에서 가상 키보드 등장 시 모달 내용이 보이지 않는 문제 해결
<br>

## ✍️ 관련 설명
- /onboarding/habit 에서 장소 입력 시 확인 가능
- Visual Viewport API를 사용하여 구현
- 가상 키보드 등장 시 모달의 세로 길이와 `position: fixed`의 `bottom` 값을 조정
- 공통 컴포넌트인 Header와 FooterBtn의 위치 조정이 어려워서 모달에 `transform: translate(0, 0)` 적용 
  (위치 조정 하지 않으면 화면을 벗어나서 보이지 않음)
- scrollable CSS 코드 및 빈 div 태그는 사파리에서 가상 키보드 등장 시 생기는 가상 영역의 스크롤을 막기 위해 추가
- 아래 환경을 고려하여 가장 버벅임이 적은 방식 적용
    - 브라우저(주소창 보임/안보임, 위치 변동)
    - PWA(주소창 없음)
- 참고: 안드로이드에서 PWA 테스트가 어려워 배포 후 추가 확인 필요
<br>

## ⭐️ Review point
더 괜찮은 방식이 있다면 말씀 부탁드려요
<br>

## 📷 Demo
수정 전 문제 화면 및 동작 영상은 [구축 진행 관리 문서](https://www.notion.so/habit-buddy/a88812ecf59a44af923bd1eed1274ca5)를 참고해 주세요

<br>


[TS-422]: https://m2jun.atlassian.net/browse/TS-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ